### PR TITLE
Allow more types in PersistentStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ Trying to delete non-existent items raises an KeyNotFoundError.
 
 This storage instance automatically loads saved data on program start and saves its data on program exit.
 
-It can only hold values of type str, int, list or dict.
+It can only hold values of type bool, int, float, str, list, dict, tuple or None.
 
 Example usage:
 

--- a/src/abllib/storage/_persistent_storage.py
+++ b/src/abllib/storage/_persistent_storage.py
@@ -45,7 +45,7 @@ class _PersistentStorage(_BaseStorage):
     def __setitem__(self, key: str, item: Any) -> None:
         # TODO: type check list / dict content types
 
-        if not isinstance(item, (str, int, list, dict)):
+        if not isinstance(item, (bool, int, float, str, list, dict, tuple)) and item is not None:
             raise TypeError(f"Tried to add item with type {type(item)} to PersistentStorage")
 
         return super().__setitem__(key, item)

--- a/src/test/storage_test.py
+++ b/src/test/storage_test.py
@@ -90,14 +90,22 @@ def test_persistentstorage_valuetype():
     PersistentStorage = storage._persistent_storage._PersistentStorage()
     PersistentStorage._store = {}
 
-    PersistentStorage["key1"] = "value"
-    assert PersistentStorage["key1"] == "value"
+    PersistentStorage["key1"] = True
+    assert PersistentStorage["key1"] is True
     PersistentStorage["key1"] = 10
     assert PersistentStorage["key1"] == 10
+    PersistentStorage["key1"] = 10.1
+    assert PersistentStorage["key1"] == 10.1
+    PersistentStorage["key1"] = "value"
+    assert PersistentStorage["key1"] == "value"
     PersistentStorage["key1"] = ["1", "2"]
     assert PersistentStorage["key1"] == ["1", "2"]
     PersistentStorage["key1"] = {"key": "item"}
     assert PersistentStorage["key1"] == {"key": "item"}
+    PersistentStorage["key1"] = ("1", "2")
+    assert PersistentStorage["key1"] == ("1", "2")
+    PersistentStorage["key1"] = None
+    assert PersistentStorage["key1"] is None
 
     class CustomType():
         pass


### PR DESCRIPTION
The new accepted types are:
* bool
* float
* tuple
* None
