### PR TITLE
Improve storage initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,21 +438,23 @@ Enable all storages:
 >> storage.initialize()
 ```
 
-Alternatively, only the VolatileStorage can be enabled:
+Alternatively, only the needed storages can be enabled:
 ```py
->> from abllib import VolatileStorage
+>> from abllib import VolatileStorage, PersistentStorage
 >> VolatileStorage.initialize()
+>> PersistentStorage.initialize()
 ```
 
 #### VolatileStorage (`abllib.VolatileStorage`)
 
-This storage instance can hold any type of value. The stored data is reset after each program restart.
+This storage can hold any type of value. The stored data is reset after each program restart.
 
 Example usage:
 
-First the storage needs to be imported:
+First the storage needs to be imported and initialized:
 ```py
 >> from abllib import VolatileStorage
+>> VolatileStorage.initialize()
 ```
 
 Items can be assigned in multiple ways:
@@ -499,21 +501,31 @@ Items can be deleted in multiple ways:
 ```py
 >> del VolatileStorage["mykey"]
 >> del VolatileStorage["toplevelkey"]["sublevelkey"]
->> del VolatileStorage["toplevelkey.sublevelkey"] # TODO: implement properly
+>> del VolatileStorage["toplevelkey.sublevelkey"]
 ```
-Trying to delete non-existent items raises an KeyNotFoundError.
+Trying to delete non-existent items raises a KeyNotFoundError.
 
 #### PersistentStorage (`abllib.PersistentStorage`)
 
-This storage instance automatically loads saved data on program start and saves its data on program exit.
+This storage automatically loads saved data on program start.
+It can also save its data on program exit, if desired.
 
-It can only hold values of type bool, int, float, str, list, dict, tuple or None.
+It can only hold values of the following types:
+* bool
+* int
+* float
+* str
+* list
+* dict
+* tuple
+* None
 
 Example usage:
 
-First the storage needs to be imported:
+First the storage needs to be imported and initialized:
 ```py
 >> from abllib import PersistentStorage
+>> PersistentStorage.initialize(save_on_exit=True)
 ```
 
 Items can be assigned in multiple ways:
@@ -557,7 +569,7 @@ Items can be deleted in multiple ways:
 ```py
 >> del PersistentStorage["mykey"]
 >> del PersistentStorage["toplevelkey"]["sublevelkey"]
->> del PersistentStorage["toplevelkey.sublevelkey"] # TODO: implement properly
+>> del PersistentStorage["toplevelkey.sublevelkey"]
 ```
 Trying to delete non-existent items raises an KeyNotFoundError.
 
@@ -569,13 +581,13 @@ All storage data can be loaded and saved manually:
 
 #### StorageView (`abllib.StorageView`)
 
-This instance is a read-only view on both VolatileStorage and PersistentStorage. It is useful to check whether a key exists in any of the storages.
+Implements a read-only view on any loaded storage. It is useful to check whether a key exists in any of the storages.
 
-The StorageView first checks PersistentStorage, then VolatileStorage.
+The StorageView checks storages in the order in which they were initialized.
 
 Example usage:
 
-First the storage needs to be imported:
+First the view needs to be imported:
 ```py
 >> from abllib import StorageView
 ```

--- a/src/abllib/_storage/_internal_storage.py
+++ b/src/abllib/_storage/_internal_storage.py
@@ -20,6 +20,6 @@ class _InternalStorage(_BaseStorage):
 
     def __setitem__(self, key: str, item: Any) -> None:
         if not key.startswith("_"):
-            raise error.InternalFunctionUsedError("Please use storage.VolatileStorage instead")
+            raise error.InternalFunctionUsedError("Please use storage.VolatileStorage")
 
         return super().__setitem__(key, item)

--- a/src/abllib/storage/__init__.py
+++ b/src/abllib/storage/__init__.py
@@ -4,16 +4,12 @@ from .._storage import _base_storage, _internal_storage
 from ._persistent_storage import _PersistentStorage
 from ._volatile_storage import _VolatileStorage
 from ._storage_view import _StorageView
-from .. import wrapper
 
 # pylint: disable=protected-access
 
-@wrapper.singleuse
 def initialize(filename: str = "storage.json", save_on_exit: bool = False):
     """
     Initialize the storage module.
-
-    This function can only be called once.
 
     If save_on_exit is set to True, automatically calls PersistentStorage.save_to_disk on application exit.
     """

--- a/src/abllib/storage/__init__.py
+++ b/src/abllib/storage/__init__.py
@@ -1,7 +1,5 @@
 """A module containing json-like storages"""
 
-import atexit
-
 from .._storage import _base_storage, _internal_storage
 from ._persistent_storage import _PersistentStorage
 from ._volatile_storage import _VolatileStorage
@@ -11,21 +9,20 @@ from .. import wrapper
 # pylint: disable=protected-access
 
 @wrapper.singleuse
-def initialize(filename: str = "storage.json"):
+def initialize(filename: str = "storage.json", save_on_exit: bool = False):
     """
     Initialize the storage module.
 
     This function can only be called once.
+
+    If save_on_exit is set to True, automatically calls PersistentStorage.save_to_disk on application exit.
     """
 
     VolatileStorage.initialize()
     StorageView.add_storage(VolatileStorage)
 
-    PersistentStorage.initialize(filename)
+    PersistentStorage.initialize(filename, save_on_exit)
     StorageView.add_storage(PersistentStorage)
-
-    # save persistent storage before program exits
-    atexit.register(PersistentStorage.save_to_disk)
 
 VolatileStorage = _VolatileStorage()
 PersistentStorage = _PersistentStorage()

--- a/src/abllib/storage/_persistent_storage.py
+++ b/src/abllib/storage/_persistent_storage.py
@@ -37,7 +37,7 @@ class _PersistentStorage(_BaseStorage):
             if InternalStorage.contains_item("_storage_file", full_filepath):
                 # the storage file didn't change
                 return
-            
+
             # save current store to old file
             self.save_to_disk()
 

--- a/src/abllib/storage/_persistent_storage.py
+++ b/src/abllib/storage/_persistent_storage.py
@@ -9,7 +9,7 @@ from typing import Any
 from .._storage import InternalStorage
 from .._storage._base_storage import _BaseStorage
 from ..storage._storage_view import _StorageView
-from .. import error, fs, wrapper
+from .. import error, fs, onexit, wrapper
 
 class _PersistentStorage(_BaseStorage):
     """Storage that is persistent across restarts"""
@@ -17,11 +17,13 @@ class _PersistentStorage(_BaseStorage):
     def __init__(self) -> None:
         pass
 
-    def initialize(self, filename: str = "storage.json"):
+    def initialize(self, filename: str = "storage.json", save_on_exit: bool = False):
         """
         Initialize only the PersistentStorage.
 
         Not needed if you already called abllib.storage.initialize().
+
+        If save_on_exit is set to True, automatically calls save_to_disk on application exit.
         """
 
         if _PersistentStorage._instance is not None:
@@ -38,6 +40,9 @@ class _PersistentStorage(_BaseStorage):
 
         InternalStorage["_storage_file"] = full_filepath
         self.load_from_disk()
+
+        if save_on_exit:
+            onexit.register("PersistentStorage.save", self.save_to_disk)
 
     _LOCK_NAME = "_PersistentStorage"
 

--- a/src/abllib/storage/_volatile_storage.py
+++ b/src/abllib/storage/_volatile_storage.py
@@ -23,6 +23,8 @@ class _VolatileStorage(_BaseStorage):
         _VolatileStorage._store = self._store = {}
         _VolatileStorage._instance = self
 
+        # we cannot use StorageView defined in __init__.py because of circular imports
+        # pylint: disable-next=protected-access
         _StorageView._instance.add_storage(self)
 
     _LOCK_NAME = "_VolatileStorage"

--- a/src/abllib/storage/_volatile_storage.py
+++ b/src/abllib/storage/_volatile_storage.py
@@ -1,6 +1,7 @@
 """Module containing the _VolatileStorage class"""
 
 from .._storage._base_storage import _BaseStorage
+from ..storage._storage_view import _StorageView
 from .. import error, wrapper
 
 class _VolatileStorage(_BaseStorage):
@@ -11,7 +12,7 @@ class _VolatileStorage(_BaseStorage):
 
     def initialize(self):
         """
-        Initialize only the VolatileStorage. Useful if you don't need the PersistentStorage.
+        Initialize only the VolatileStorage.
 
         Not needed if you already called abllib.storage.initialize().
         """
@@ -21,6 +22,8 @@ class _VolatileStorage(_BaseStorage):
 
         _VolatileStorage._store = self._store = {}
         _VolatileStorage._instance = self
+
+        _StorageView._instance.add_storage(self)
 
     _LOCK_NAME = "_VolatileStorage"
 

--- a/src/abllib/storage/_volatile_storage.py
+++ b/src/abllib/storage/_volatile_storage.py
@@ -21,6 +21,7 @@ class _VolatileStorage(_BaseStorage):
         """
 
         if _VolatileStorage._store is not None:
+            # this is a re-initialization
             return
 
         _VolatileStorage._store = self._store = {}

--- a/src/abllib/storage/_volatile_storage.py
+++ b/src/abllib/storage/_volatile_storage.py
@@ -8,7 +8,10 @@ class _VolatileStorage(_BaseStorage):
     """Storage that is not saved across restarts"""
 
     def __init__(self) -> None:
-        pass
+        if _VolatileStorage._instance is not None:
+            raise error.SingletonInstantiationError.with_values(_VolatileStorage)
+
+        _VolatileStorage._instance = self
 
     def initialize(self):
         """
@@ -17,11 +20,10 @@ class _VolatileStorage(_BaseStorage):
         Not needed if you already called abllib.storage.initialize().
         """
 
-        if _VolatileStorage._instance is not None:
-            raise error.SingletonInstantiationError.with_values(_VolatileStorage)
+        if _VolatileStorage._store is not None:
+            return
 
         _VolatileStorage._store = self._store = {}
-        _VolatileStorage._instance = self
 
         # we cannot use StorageView defined in __init__.py because of circular imports
         # pylint: disable-next=protected-access

--- a/src/test/fixtures.py
+++ b/src/test/fixtures.py
@@ -52,11 +52,11 @@ def clean_after_function():
         del storage.PersistentStorage[key]
 
     for key in list(storage.VolatileStorage._store.keys()):
-        if key not in ["storage_file"]:
-            del storage.VolatileStorage[key]
+        del storage.VolatileStorage[key]
 
     for key in list(_storage.InternalStorage._store.keys()):
-        del _storage.InternalStorage[key]
+        if key not in ["_storage_file"]:
+            del _storage.InternalStorage[key]
 
 @pytest.fixture(scope="function", autouse=False)
 def capture_logs():

--- a/src/test/fixtures.py
+++ b/src/test/fixtures.py
@@ -4,7 +4,6 @@
 
 # pylint: disable=protected-access, missing-class-docstring
 
-import atexit
 import os
 import shutil
 
@@ -34,9 +33,6 @@ def setup():
         os.remove(STORAGE_FILE)
 
     storage.initialize(STORAGE_FILE)
-
-    # disable atexit storage saving
-    atexit.unregister(storage.PersistentStorage.save_to_disk)
 
     yield None
 

--- a/src/test/i_storage_test.py
+++ b/src/test/i_storage_test.py
@@ -4,18 +4,19 @@
 
 import pytest
 
-from abllib import error, _storage
+from abllib import error
+from abllib._storage import _BaseStorage, _InternalStorage
 
 def test_basestorage_instantiation():
     """Ensure that BaseStorage cannot be initialized"""
 
     with pytest.raises(NotImplementedError):
-        _storage._base_storage._BaseStorage()
+        _BaseStorage()
 
 def test_basestorage_getitem():
     """Test the Storage.__getitem__() method"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     BaseStorage._store["key1"] = "value"
@@ -28,7 +29,7 @@ def test_basestorage_getitem():
 def test_basestorage_getitem_multi():
     """Test the Storage.__getitem__() method with subdicts specified in the key"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     BaseStorage._store["key1"] = {}
@@ -46,7 +47,7 @@ def test_basestorage_getitem_multi():
 def test_basestorage_getitem_keytype():
     """Test the Storage.__getitem__() methods' protection against incorrect key types"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     with pytest.raises(TypeError):
@@ -59,7 +60,7 @@ def test_basestorage_getitem_keytype():
 def test_basestorage_getitem_valuetype():
     """Test the Storage.__getitem__() methods' support for different value types"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     BaseStorage._store["key1"] = ["1", 2, None]
@@ -68,7 +69,7 @@ def test_basestorage_getitem_valuetype():
 def test_basestorage_getitem_wrong_key():
     """Test the Storage.__getitem__() methods' protection against nonexistent keys"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     with pytest.raises(error.KeyNotFoundError):
@@ -81,7 +82,7 @@ def test_basestorage_getitem_wrong_key():
 def test_basestorage_setitem():
     """Test the Storage.__setitem__() method"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     BaseStorage["key1"] = "value"
@@ -94,7 +95,7 @@ def test_basestorage_setitem():
 def test_basestorage_setitem_multi():
     """Test the Storage.__setitem__() method with subdicts specified in the key"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     BaseStorage["key1"] = {}
@@ -112,7 +113,7 @@ def test_basestorage_setitem_multi():
 def test_basestorage_setitem_create_subdict():
     """Test the Storage.__setitem__() methods' ability to create missing 'inbetween' dictionaries"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     BaseStorage["key1.key2"] = "value2"
@@ -128,7 +129,7 @@ def test_basestorage_setitem_create_subdict():
 def test_basestorage_setitem_keytype():
     """Test the Storage.__setitem__() methods' protection against incorrect key types"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     with pytest.raises(TypeError):
@@ -141,7 +142,7 @@ def test_basestorage_setitem_keytype():
 def test_basestorage_setitem_valuetype():
     """Test the Storage.__setitem__() methods' support for different value types"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     BaseStorage["key1"] = ["1", 2, None]
@@ -156,7 +157,7 @@ def test_basestorage_setitem_valuetype():
 def test_basestorage_delitem():
     """Test the Storage.__delitem__() method"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     BaseStorage._store["key1"] = "value"
@@ -166,7 +167,7 @@ def test_basestorage_delitem():
 def test_basestorage_delitem_multi():
     """Test the Storage.__delitem__() method with subdicts specified in the key"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     BaseStorage._store["key1"] = {}
@@ -217,7 +218,7 @@ def test_basestorage_delitem_multi():
 def test_basestorage_delitem_keytype():
     """Test the Storage.__delitem__() methods' protection against incorrect key types"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     with pytest.raises(TypeError):
@@ -230,7 +231,7 @@ def test_basestorage_delitem_keytype():
 def test_basestorage_delitem_wrong_key():
     """Test the Storage.__delitem__() methods' protection against nonexistent keys"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     with pytest.raises(error.KeyNotFoundError):
@@ -243,7 +244,7 @@ def test_basestorage_delitem_wrong_key():
 def test_basestorage_pop():
     """Test the Storage.pop() method"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     BaseStorage._store["key1"] = "value"
@@ -254,7 +255,7 @@ def test_basestorage_pop():
 def test_basestorage_pop_multi():
     """Test the Storage.pop() method with subdicts specified in the key"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     BaseStorage._store["key1"] = {}
@@ -282,7 +283,7 @@ def test_basestorage_pop_multi():
 def test_basestorage_pop_keytype():
     """Test the Storage.pop() methods' protection against incorrect key types"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     with pytest.raises(TypeError):
@@ -295,7 +296,7 @@ def test_basestorage_pop_keytype():
 def test_basestorage_pop_wrong_key():
     """Test the Storage.pop() methods' protection against nonexistent keys"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     with pytest.raises(error.KeyNotFoundError):
@@ -308,7 +309,7 @@ def test_basestorage_pop_wrong_key():
 def test_basestorage_contains():
     """Test the Storage.contains() method"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     assert not BaseStorage.contains("key1")
@@ -321,7 +322,7 @@ def test_basestorage_contains():
 def test_basestorage_contains_multi():
     """Test the Storage.contains() method with subdicts specified in the key"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     assert not BaseStorage.contains("key1.key2")
@@ -343,7 +344,7 @@ def test_basestorage_contains_multi():
 def test_basestorage_contains_keytype():
     """Test the Storage.contains() methods' protection against incorrect key types"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     with pytest.raises(TypeError):
@@ -356,7 +357,7 @@ def test_basestorage_contains_keytype():
 def test_basestorage_contains_item():
     """Test the Storage.contains_item() method"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     assert not BaseStorage.contains_item("key1", "value")
@@ -367,7 +368,7 @@ def test_basestorage_contains_item():
 def test_basestorage_contains_item_multi():
     """Test the Storage.contains_item() method with subdicts specified in the key"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     assert not BaseStorage.contains_item("key1.key2", "value")
@@ -385,7 +386,7 @@ def test_basestorage_contains_item_multi():
 def test_basestorage_contains_item_keytype():
     """Test the Storage.contains_item() methods' protection against incorrect key types"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     with pytest.raises(TypeError):
@@ -398,7 +399,7 @@ def test_basestorage_contains_item_keytype():
 def test_basestorage_contains_item_valuetype():
     """Test the Storage.contains_item() methods' support for different value types"""
 
-    BaseStorage = _storage._base_storage._BaseStorage.__new__(_storage._base_storage._BaseStorage)
+    BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
     assert not BaseStorage.contains_item("key1", ["1", 2, None])
@@ -409,21 +410,24 @@ def test_basestorage_contains_item_valuetype():
 def test_internalstorage_inheritance():
     """Ensure the InternalStorage inherits from _BaseStorage"""
 
-    assert isinstance(_storage.InternalStorage, _storage._base_storage._BaseStorage)
+    InternalStorage = _InternalStorage.__new__(_InternalStorage)
+    InternalStorage._store = {}
+
+    assert isinstance(InternalStorage, _BaseStorage)
 
 def test_internalstorage_instantiation():
     """Ensure that InternalStorage behaves like a singleton"""
 
     with pytest.raises(error.SingletonInstantiationError):
-        _storage._internal_storage._InternalStorage()._init()
+        _InternalStorage()._init()
 
     with pytest.raises(error.SingletonInstantiationError):
-        _storage._internal_storage._InternalStorage()._init()
+        _InternalStorage()._init()
 
 def test_internalstorage_setitem():
     """Ensure that InternalStorage only accepts keys prefixed with '__'"""
 
-    InternalStorage = _storage._internal_storage._InternalStorage.__new__(_storage._internal_storage._InternalStorage)
+    InternalStorage = _InternalStorage.__new__(_InternalStorage)
     InternalStorage._store = {}
 
     with pytest.raises(error.InternalFunctionUsedError):

--- a/src/test/storage_test.py
+++ b/src/test/storage_test.py
@@ -7,30 +7,32 @@ import os
 
 import pytest
 
-from abllib import error, storage, _storage
+from abllib import error, _storage
+from abllib.storage import _VolatileStorage, _PersistentStorage, _StorageView
+from abllib._storage._base_storage import _BaseStorage
 
 def test_volatilestorage_inheritance():
     """Ensure the VolatileStorage inherits from _BaseStorage"""
 
-    VolatileStorage = storage._volatile_storage._VolatileStorage()
+    VolatileStorage = _VolatileStorage.__new__(_VolatileStorage)
     VolatileStorage._store = {}
 
-    assert isinstance(VolatileStorage, _storage._base_storage._BaseStorage)
-    assert not isinstance(VolatileStorage, storage._persistent_storage._PersistentStorage)
+    assert isinstance(VolatileStorage, _BaseStorage)
+    assert not isinstance(VolatileStorage, _PersistentStorage)
 
 def test_volatilestorage_instantiation():
     """Ensure that VolatileStorage behaves like a singleton"""
 
     with pytest.raises(error.SingletonInstantiationError):
-        storage._volatile_storage._VolatileStorage().initialize()
+        _VolatileStorage()
 
     with pytest.raises(error.SingletonInstantiationError):
-        storage._volatile_storage._VolatileStorage().initialize()
+        _VolatileStorage()
 
 def test_volatilestorage_valuetype():
     """Test the VolatileStorages' support for different value types"""
 
-    VolatileStorage = storage._volatile_storage._VolatileStorage()
+    VolatileStorage = _VolatileStorage.__new__(_VolatileStorage)
     VolatileStorage._store = {}
 
     VolatileStorage["key1"] = ["1", 2, None]
@@ -45,7 +47,7 @@ def test_volatilestorage_valuetype():
 def test_volatilestorage_noinit_error():
     """Ensure the VolatileStorage methods don't work before initialization is complete"""
 
-    VolatileStorage = storage._volatile_storage._VolatileStorage()
+    VolatileStorage = _VolatileStorage.__new__(_VolatileStorage)
     VolatileStorage._store = None
 
     with pytest.raises(error.NotInitializedError):
@@ -69,7 +71,7 @@ def test_volatilestorage_noinit_error():
 def test_volatilestorage_del_autoremovedict():
     """Test that AutoremoveDicts are correctly deleted on del"""
 
-    VolatileStorage = storage._volatile_storage._VolatileStorage()
+    VolatileStorage = _VolatileStorage.__new__(_VolatileStorage)
     VolatileStorage._store = {}
 
     VolatileStorage["key1.key2.key3.key4.key5.key6"] = "values"
@@ -83,25 +85,25 @@ def test_volatilestorage_del_autoremovedict():
 def test_persistentstorage_inheritance():
     """Ensure the PersistentStorage inherits from _BaseStorage"""
 
-    PersistentStorage = storage._persistent_storage._PersistentStorage()
+    PersistentStorage = _PersistentStorage.__new__(_PersistentStorage)
     PersistentStorage._store = {}
 
-    assert isinstance(PersistentStorage, _storage._base_storage._BaseStorage)
-    assert not isinstance(PersistentStorage, storage._volatile_storage._VolatileStorage)
+    assert isinstance(PersistentStorage, _BaseStorage)
+    assert not isinstance(PersistentStorage, _VolatileStorage)
 
 def test_persistentstorage_instantiation():
     """Ensure that PersistentStorage behaves like a singleton"""
 
     with pytest.raises(error.SingletonInstantiationError):
-        storage._persistent_storage._PersistentStorage().initialize("test.json")
+        _PersistentStorage()
 
     with pytest.raises(error.SingletonInstantiationError):
-        storage._persistent_storage._PersistentStorage().initialize("test.json")
+        _PersistentStorage()
 
 def test_persistentstorage_valuetype():
     """Test the PersistentStorages' support for different value types"""
 
-    PersistentStorage = storage._persistent_storage._PersistentStorage()
+    PersistentStorage = _PersistentStorage.__new__(_PersistentStorage)
     PersistentStorage._store = {}
 
     PersistentStorage["key1"] = True
@@ -130,7 +132,7 @@ def test_persistentstorage_valuetype():
 def test_persistentstorage_load_file():
     """Test the PersistentStorage._load_from_disk() method"""
 
-    PersistentStorage = storage._persistent_storage._PersistentStorage()
+    PersistentStorage = _PersistentStorage.__new__(_PersistentStorage)
     PersistentStorage._store = {}
 
     filepath = _storage.InternalStorage["_storage_file"]
@@ -157,7 +159,7 @@ def test_persistentstorage_load_file():
 def test_persistentstorage_save_file():
     """Test the PersistentStorage._save_to_disk() method"""
 
-    PersistentStorage = storage._persistent_storage._PersistentStorage()
+    PersistentStorage = _PersistentStorage.__new__(_PersistentStorage)
     PersistentStorage._store = {}
 
     filepath = _storage.InternalStorage["_storage_file"]
@@ -183,7 +185,7 @@ def test_persistentstorage_save_file_empty():
     if the PersistentStorage is empty
     """
 
-    PersistentStorage = storage._persistent_storage._PersistentStorage()
+    PersistentStorage = _PersistentStorage.__new__(_PersistentStorage)
     PersistentStorage._store = {}
 
     filepath = _storage.InternalStorage["_storage_file"]
@@ -201,7 +203,7 @@ def test_persistentstorage_save_file_empty():
 def test_persistentstorage_noinit_error():
     """Ensure the PersistentStorage methods don't work before initialization is complete"""
 
-    PersistentStorage = storage._persistent_storage._PersistentStorage()
+    PersistentStorage = _PersistentStorage.__new__(_PersistentStorage)
     PersistentStorage._store = None
 
     with pytest.raises(error.NotInitializedError):
@@ -225,7 +227,7 @@ def test_persistentstorage_noinit_error():
 def test_persistentstorage_del_autoremovedict():
     """Test that AutoremoveDicts are correctly deleted on del"""
 
-    PersistentStorage = storage._persistent_storage._PersistentStorage()
+    PersistentStorage = _PersistentStorage.__new__(_PersistentStorage)
     PersistentStorage._store = {}
 
     PersistentStorage["key1.key2.key3.key4.key5.key6"] = "values"
@@ -239,11 +241,11 @@ def test_persistentstorage_del_autoremovedict():
 def test_storageview_instantiation():
     """Ensure that instantiating StorageView only works with valid arguments"""
 
-    VolatileStorage = storage._volatile_storage._VolatileStorage()
+    VolatileStorage = _VolatileStorage.__new__(_VolatileStorage)
     VolatileStorage._store = {}
-    PersistentStorage = storage._persistent_storage._PersistentStorage()
+    PersistentStorage = _PersistentStorage.__new__(_PersistentStorage)
     PersistentStorage._store = {}
-    StorageView = storage._StorageView()
+    StorageView = _StorageView()
     StorageView._storages = []
     StorageView.add_storage(VolatileStorage)
     StorageView.add_storage(PersistentStorage)
@@ -257,11 +259,11 @@ def test_storageview_instantiation():
 def test_storageview_getitem():
     """Test the Storage.__getitem__() method"""
 
-    VolatileStorage = storage._volatile_storage._VolatileStorage()
+    VolatileStorage = _VolatileStorage.__new__(_VolatileStorage)
     VolatileStorage._store = {}
-    PersistentStorage = storage._persistent_storage._PersistentStorage()
+    PersistentStorage = _PersistentStorage.__new__(_PersistentStorage)
     PersistentStorage._store = {}
-    StorageView = storage._StorageView()
+    StorageView = _StorageView()
     StorageView._storages = []
     StorageView.add_storage(VolatileStorage)
     StorageView.add_storage(PersistentStorage)
@@ -282,11 +284,11 @@ def test_storageview_getitem():
 def test_storageview_contains():
     """Test the Storage.contains() method"""
 
-    VolatileStorage = storage._volatile_storage._VolatileStorage()
+    VolatileStorage = _VolatileStorage.__new__(_VolatileStorage)
     VolatileStorage._store = {}
-    PersistentStorage = storage._persistent_storage._PersistentStorage()
+    PersistentStorage = _PersistentStorage.__new__(_PersistentStorage)
     PersistentStorage._store = {}
-    StorageView = storage._StorageView()
+    StorageView = _StorageView()
     StorageView._storages = []
     StorageView.add_storage(VolatileStorage)
     StorageView.add_storage(PersistentStorage)
@@ -311,11 +313,11 @@ def test_storageview_contains():
 def test_storageview_contains_item():
     """Test the Storage.contains_item() method"""
 
-    VolatileStorage = storage._volatile_storage._VolatileStorage()
+    VolatileStorage = _VolatileStorage.__new__(_VolatileStorage)
     VolatileStorage._store = {}
-    PersistentStorage = storage._persistent_storage._PersistentStorage()
+    PersistentStorage = _PersistentStorage.__new__(_PersistentStorage)
     PersistentStorage._store = {}
-    StorageView = storage._StorageView()
+    StorageView = _StorageView()
     StorageView._storages = []
     StorageView.add_storage(VolatileStorage)
     StorageView.add_storage(PersistentStorage)
@@ -336,11 +338,11 @@ def test_storageview_contains_item():
 def test_storageview_noinit_error():
     """Ensure the StorageView methods don't work before initialization is complete"""
 
-    VolatileStorage = storage._volatile_storage._VolatileStorage()
+    VolatileStorage = _VolatileStorage.__new__(_VolatileStorage)
     VolatileStorage._store = None
-    PersistentStorage = storage._persistent_storage._PersistentStorage()
+    PersistentStorage = _PersistentStorage.__new__(_PersistentStorage)
     PersistentStorage._store = None
-    StorageView = storage._StorageView()
+    StorageView = _StorageView()
     StorageView._storages = []
     StorageView.add_storage(VolatileStorage)
     StorageView.add_storage(PersistentStorage)


### PR DESCRIPTION
Now all storages can be initialized multiple times. If an already initialized storage is initialized again, only the newest configuration is used.

Re-initializing the PersistentStorage with a different storage file will save the current data to the old storage file and use the new one in the future.