### PR TITLE
Define behaviour of wrapper.singleuse if an error occurs in the wrapped function

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,41 @@ True
 
 This module contains general-purpose [wrappers](https://www.geeksforgeeks.org/function-wrappers-in-python/).
 
+#### Singleuse functions (`abllib.wrapper.singleuse`)
+
+The singleuse wrapper can be applied to functions to make them single-useable.
+If an already called function is called again, an CalledMultipleTimesError is raised.
+
+Example usage:
+```py
+>> from abllib.wrapper import singleuse
+>> @singleuse
+.. def my_func(arg):
+    print(arg)
+>> my_func("hello world")
+hello world
+>> my_func("hello world")
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+abllib.error._general.CalledMultipleTimesError: The function can only be called once
+```
+
+If an error occured during function execution, the function can be called again.
+```py
+>> from abllib.wrapper import singleuse
+>> @singleuse
+.. def my_func(arg):
+    raise FileNotFoundError()
+>> my_func("hello world")
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+    raise FileNotFoundError()
+>> my_func("hello world")
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+    raise FileNotFoundError()
+```
+
 #### Custom lock (`abllib.wrapper.Lock`)
 
 The wrapper module contains a modified version of threading.Lock.

--- a/src/abllib/wrapper/_singleuse_wrapper.py
+++ b/src/abllib/wrapper/_singleuse_wrapper.py
@@ -6,9 +6,10 @@ from ..error import CalledMultipleTimesError
 
 def singleuse(func):
     """
-    Make a function single-use only
+    Make a function single-use only.
+    If the function raised an exception, it is not seen as called and can be used again.
 
-    Calling the function twice raises an error.CalledMultipleTimesError
+    Calling the function twice raises an error.CalledMultipleTimesError.
     """
 
     was_called = [False]
@@ -20,8 +21,10 @@ def singleuse(func):
         if was_called[0]:
             raise CalledMultipleTimesError()
 
+        res = func(*args, **kwargs)
+
         was_called[0] = True
 
-        return func(*args, **kwargs)
+        return res
 
     return wrapper

--- a/src/test/wrapper_test.py
+++ b/src/test/wrapper_test.py
@@ -194,3 +194,29 @@ def test_singleuse():
 
     with pytest.raises(error.CalledMultipleTimesError):
         func1()
+
+def test_singleuse_exception():
+    """Ensure that raised exceptions reset singleuse flag"""
+
+    data = [1, 2, 3]
+
+    @wrapper.singleuse
+    def func1():
+        if len(data) > 0:
+            data.pop(0)
+            raise error.InternalCalculationError()
+
+    with pytest.raises(error.InternalCalculationError):
+        func1()
+    with pytest.raises(error.InternalCalculationError):
+        func1()
+    with pytest.raises(error.InternalCalculationError):
+        func1()
+
+    func1()
+
+    with pytest.raises(error.CalledMultipleTimesError):
+        func1()
+
+    with pytest.raises(error.CalledMultipleTimesError):
+        func1()


### PR DESCRIPTION
If the wrapped function raises an exception, wrapper.singleuse allows it to be called again, until it completes successfully.