### PR TITLE
More tests for abllib.onexit

### DIFF
--- a/src/abllib/onexit.py
+++ b/src/abllib/onexit.py
@@ -16,6 +16,9 @@ def register(name: str, callback: Callable) -> None:
     Does not work if the application is killed with SIGKILL.
     """
 
+    if "." in name:
+        name = name.replace(".", "_")
+
     registered = False
 
     if f"_onexit.atexit.{name}" not in InternalStorage:
@@ -36,6 +39,9 @@ def register_normal_exit(name: str, callback: Callable) -> None:
     Does not work if the application is killed with SIGTERM or SIGKILL.
     """
 
+    if "." in name:
+        name = name.replace(".", "_")
+
     if f"_onexit.atexit.{name}" in InternalStorage:
         raise error.RegisteredMultipleTimesError.with_values(name)
 
@@ -49,6 +55,9 @@ def register_sigterm(name: str, callback: Callable) -> None:
     """
 
     _ensure_signal_handler()
+
+    if "." in name:
+        name = name.replace(".", "_")
 
     if f"_onexit.signal.{name}" in InternalStorage:
         raise error.RegisteredMultipleTimesError.with_values(name)

--- a/src/test/onexit_test.py
+++ b/src/test/onexit_test.py
@@ -4,6 +4,8 @@ import pytest
 
 from abllib import error, onexit
 
+# pylint: disable=protected-access
+
 def test_register():
     """Ensure that registering the same callback multiple times raises an error"""
 
@@ -72,9 +74,8 @@ def test_deregister_single():
     onexit.deregister_normal_exit("func1")
     onexit.deregister_sigterm("func1")
 
-
-def test_all():
-    """Ensure that all functions work together correctly"""
+def test_register_all():
+    """Ensure that all register functions work together correctly"""
 
     def func1():
         pass
@@ -84,3 +85,42 @@ def test_all():
     onexit.deregister("func1")
 
     onexit.register("func1", func1)
+
+def test_call_atexit():
+    """Ensure that atexit function calls callbacks correctly"""
+
+    data = [False]
+    def func1():
+        data[0] = True
+
+    onexit.register("func1", func1)
+
+    onexit._atexit_func()
+
+    assert data[0]
+
+def test_call_signal():
+    """Ensure that signal function calls callbacks correctly"""
+
+    data = [False]
+    def func1():
+        data[0] = True
+
+    onexit.register("func1", func1)
+
+    onexit._signal_func(None, None)
+
+    assert data[0]
+
+def test_dotname():
+    """Ensure that names containing a "." work as expected"""
+
+    data = [False]
+    def func1():
+        data[0] = True
+
+    onexit.register("func1.cb", func1)
+
+    onexit._atexit_func()
+
+    assert data[0]


### PR DESCRIPTION
Also fixes a bug where registering a callback with "." in the name raised an exception