### PR TITLE
Handle invalid storage keys

### DIFF
--- a/src/abllib/_storage/_base_storage.py
+++ b/src/abllib/_storage/_base_storage.py
@@ -25,9 +25,6 @@ class _BaseStorage():
         If 'key' contains a '.', also checks if all sub-dicts exist.
         """
 
-        if not isinstance(key, str):
-            raise TypeError()
-
         if not self._contains(key):
             return False
         return item == self[key]
@@ -65,15 +62,9 @@ class _BaseStorage():
     def __str__(self) -> str:
         return str(self._store)
 
-    def _ensure_initialized(self) -> None:
-        if self._store is None:
-            raise error.NotInitializedError()
-
     def _contains(self, key: str) -> bool:
         self._ensure_initialized()
-
-        if not isinstance(key, str):
-            raise TypeError()
+        self._ensure_key_validity(key)
 
         if "." not in key:
             return key in self._store
@@ -91,9 +82,7 @@ class _BaseStorage():
 
     def _get(self, key: str) -> Any:
         self._ensure_initialized()
-
-        if not isinstance(key, str):
-            raise TypeError()
+        self._ensure_key_validity(key)
 
         if "." not in key:
             if key not in self._store:
@@ -118,9 +107,7 @@ class _BaseStorage():
 
     def _set(self, key: str, item: Any) -> None:
         self._ensure_initialized()
-
-        if not isinstance(key, str):
-            raise TypeError()
+        self._ensure_key_validity(key)
 
         if "." not in key:
             self._store[key] = item
@@ -141,9 +128,7 @@ class _BaseStorage():
 
     def _del(self, key: str) -> None:
         self._ensure_initialized()
-
-        if not isinstance(key, str):
-            raise TypeError()
+        self._ensure_key_validity(key)
 
         if "." not in key:
             if key not in self._store:
@@ -195,3 +180,18 @@ class _BaseStorage():
             else:
                 # we deleted every subkey
                 return
+
+    def _ensure_initialized(self) -> None:
+        if self._store is None:
+            raise error.NotInitializedError()
+
+    def _ensure_key_validity(self, key: Any) -> None:
+        if not isinstance(key, str):
+            raise error.WrongTypeError.with_values(key, str)
+        
+        if key[0] == ".":
+            raise error.InvalidKeyError("Key cannot start with '.'")
+        if key[-1] == ".":
+            raise error.InvalidKeyError("Key cannot end with '.'")
+        if ".." in key:
+            raise error.InvalidKeyError("Key cannot contain '..'")

--- a/src/abllib/_storage/_base_storage.py
+++ b/src/abllib/_storage/_base_storage.py
@@ -188,7 +188,7 @@ class _BaseStorage():
     def _ensure_key_validity(self, key: Any) -> None:
         if not isinstance(key, str):
             raise error.WrongTypeError.with_values(key, str)
-        
+
         if key[0] == ".":
             raise error.InvalidKeyError("Key cannot start with '.'")
         if key[-1] == ".":

--- a/src/abllib/error/__init__.py
+++ b/src/abllib/error/__init__.py
@@ -6,6 +6,7 @@ from ._general import CalledMultipleTimesError, \
                       DirNotFoundError, \
                       InternalCalculationError, \
                       InternalFunctionUsedError, \
+                      InvalidKeyError, \
                       KeyNotFoundError, \
                       LockAcquisitionTimeoutError, \
                       MissingDefaultMessageError, \
@@ -26,6 +27,7 @@ __exports__ = [
     DirNotFoundError,
     InternalCalculationError,
     InternalFunctionUsedError,
+    InvalidKeyError,
     KeyNotFoundError,
     LockAcquisitionTimeoutError,
     MissingDefaultMessageError,

--- a/src/abllib/error/_general.py
+++ b/src/abllib/error/_general.py
@@ -44,6 +44,14 @@ class InternalFunctionUsedError(CustomException):
         0: "This function is only for library-internal use"
     }
 
+class InvalidKeyError(CustomException):
+    """Exception raised when the key has an invalid format"""
+
+    default_messages = {
+        0: "The key has an invalid format",
+        1: "The key '{0}' has an invalid format"
+    }
+
 class KeyNotFoundError(CustomException):
     """Exception raised when the key is not found in the storage"""
 

--- a/src/test/i_storage_test.py
+++ b/src/test/i_storage_test.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from abllib import error
+from abllib.error import InternalFunctionUsedError, InvalidKeyError, KeyNotFoundError, SingletonInstantiationError, WrongTypeError
 from abllib._storage import _BaseStorage, _InternalStorage
 
 def test_basestorage_instantiation():
@@ -50,12 +50,19 @@ def test_basestorage_getitem_keytype():
     BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
-    with pytest.raises(TypeError):
+    with pytest.raises(WrongTypeError):
         BaseStorage[None]
-    with pytest.raises(TypeError):
+    with pytest.raises(WrongTypeError):
         BaseStorage[10]
-    with pytest.raises(TypeError):
+    with pytest.raises(WrongTypeError):
         BaseStorage[list(("1",))]
+
+    with pytest.raises(InvalidKeyError):
+        BaseStorage[".some.key"]
+    with pytest.raises(InvalidKeyError):
+        BaseStorage["some.key."]
+    with pytest.raises(InvalidKeyError):
+        BaseStorage["some..key"]
 
 def test_basestorage_getitem_valuetype():
     """Test the Storage.__getitem__() methods' support for different value types"""
@@ -72,11 +79,11 @@ def test_basestorage_getitem_wrong_key():
     BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
-    with pytest.raises(error.KeyNotFoundError):
+    with pytest.raises(KeyNotFoundError):
         BaseStorage["key1"]
-    with pytest.raises(error.KeyNotFoundError):
+    with pytest.raises(KeyNotFoundError):
         BaseStorage["key1.key2"]
-    with pytest.raises(error.KeyNotFoundError):
+    with pytest.raises(KeyNotFoundError):
         BaseStorage["key1.key2.key3.key4.key5.key6"]
 
 def test_basestorage_setitem():
@@ -132,12 +139,19 @@ def test_basestorage_setitem_keytype():
     BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
-    with pytest.raises(TypeError):
+    with pytest.raises(WrongTypeError):
         BaseStorage[None] = "value"
-    with pytest.raises(TypeError):
+    with pytest.raises(WrongTypeError):
         BaseStorage[10] = "value"
-    with pytest.raises(TypeError):
+    with pytest.raises(WrongTypeError):
         BaseStorage[list(("1",))] = "value"
+
+    with pytest.raises(InvalidKeyError):
+        BaseStorage[".some.key"] = "value"
+    with pytest.raises(InvalidKeyError):
+        BaseStorage["some.key."] = "value"
+    with pytest.raises(InvalidKeyError):
+        BaseStorage["some..key"] = "value"
 
 def test_basestorage_setitem_valuetype():
     """Test the Storage.__setitem__() methods' support for different value types"""
@@ -221,12 +235,19 @@ def test_basestorage_delitem_keytype():
     BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
-    with pytest.raises(TypeError):
+    with pytest.raises(WrongTypeError):
         del BaseStorage[None]
-    with pytest.raises(TypeError):
+    with pytest.raises(WrongTypeError):
         del BaseStorage[10]
-    with pytest.raises(TypeError):
+    with pytest.raises(WrongTypeError):
         del BaseStorage[list(("1",))]
+
+    with pytest.raises(InvalidKeyError):
+        del BaseStorage[".some.key"]
+    with pytest.raises(InvalidKeyError):
+        del BaseStorage["some.key."]
+    with pytest.raises(InvalidKeyError):
+        del BaseStorage["some..key"]
 
 def test_basestorage_delitem_wrong_key():
     """Test the Storage.__delitem__() methods' protection against nonexistent keys"""
@@ -234,11 +255,11 @@ def test_basestorage_delitem_wrong_key():
     BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
-    with pytest.raises(error.KeyNotFoundError):
+    with pytest.raises(KeyNotFoundError):
         del BaseStorage["key1"]
-    with pytest.raises(error.KeyNotFoundError):
+    with pytest.raises(KeyNotFoundError):
         del BaseStorage["key1.key2"]
-    with pytest.raises(error.KeyNotFoundError):
+    with pytest.raises(KeyNotFoundError):
         del BaseStorage["key1.key2.key3.key4.key5.key6"]
 
 def test_basestorage_pop():
@@ -286,12 +307,19 @@ def test_basestorage_pop_keytype():
     BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
-    with pytest.raises(TypeError):
+    with pytest.raises(WrongTypeError):
         BaseStorage.pop(None)
-    with pytest.raises(TypeError):
+    with pytest.raises(WrongTypeError):
         BaseStorage.pop(10)
-    with pytest.raises(TypeError):
+    with pytest.raises(WrongTypeError):
         BaseStorage.pop(list(("1",)))
+
+    with pytest.raises(InvalidKeyError):
+        BaseStorage.pop(".some.key")
+    with pytest.raises(InvalidKeyError):
+        BaseStorage.pop("some.key.")
+    with pytest.raises(InvalidKeyError):
+        BaseStorage.pop("some..key")
 
 def test_basestorage_pop_wrong_key():
     """Test the Storage.pop() methods' protection against nonexistent keys"""
@@ -299,11 +327,11 @@ def test_basestorage_pop_wrong_key():
     BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
-    with pytest.raises(error.KeyNotFoundError):
+    with pytest.raises(KeyNotFoundError):
         BaseStorage.pop("key1")
-    with pytest.raises(error.KeyNotFoundError):
+    with pytest.raises(KeyNotFoundError):
         BaseStorage.pop("key1.key2")
-    with pytest.raises(error.KeyNotFoundError):
+    with pytest.raises(KeyNotFoundError):
         BaseStorage.pop("key1.key2.key3.key4.key5.key6")
 
 def test_basestorage_contains():
@@ -347,12 +375,19 @@ def test_basestorage_contains_keytype():
     BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
-    with pytest.raises(TypeError):
+    with pytest.raises(WrongTypeError):
         None in BaseStorage
-    with pytest.raises(TypeError):
+    with pytest.raises(WrongTypeError):
         10 in BaseStorage
-    with pytest.raises(TypeError):
+    with pytest.raises(WrongTypeError):
         list(("1",)) in BaseStorage
+
+    with pytest.raises(InvalidKeyError):
+        ".some.key" in BaseStorage
+    with pytest.raises(InvalidKeyError):
+        "some.key." in BaseStorage
+    with pytest.raises(InvalidKeyError):
+        "some..key" in BaseStorage
 
 def test_basestorage_contains_item():
     """Test the Storage.contains_item() method"""
@@ -389,12 +424,19 @@ def test_basestorage_contains_item_keytype():
     BaseStorage = _BaseStorage.__new__(_BaseStorage)
     BaseStorage._store = {}
 
-    with pytest.raises(TypeError):
+    with pytest.raises(WrongTypeError):
         BaseStorage.contains_item(None, "value")
-    with pytest.raises(TypeError):
+    with pytest.raises(WrongTypeError):
         BaseStorage.contains_item(10, "value")
-    with pytest.raises(TypeError):
+    with pytest.raises(WrongTypeError):
         BaseStorage.contains_item(list(("1",)), "value")
+
+    with pytest.raises(InvalidKeyError):
+        BaseStorage.contains_item(".some.key", "value")
+    with pytest.raises(InvalidKeyError):
+        BaseStorage.contains_item("some.key.", "value")
+    with pytest.raises(InvalidKeyError):
+        BaseStorage.contains_item("some..key", "value")
 
 def test_basestorage_contains_item_valuetype():
     """Test the Storage.contains_item() methods' support for different value types"""
@@ -418,10 +460,10 @@ def test_internalstorage_inheritance():
 def test_internalstorage_instantiation():
     """Ensure that InternalStorage behaves like a singleton"""
 
-    with pytest.raises(error.SingletonInstantiationError):
+    with pytest.raises(SingletonInstantiationError):
         _InternalStorage()._init()
 
-    with pytest.raises(error.SingletonInstantiationError):
+    with pytest.raises(SingletonInstantiationError):
         _InternalStorage()._init()
 
 def test_internalstorage_setitem():
@@ -430,11 +472,11 @@ def test_internalstorage_setitem():
     InternalStorage = _InternalStorage.__new__(_InternalStorage)
     InternalStorage._store = {}
 
-    with pytest.raises(error.InternalFunctionUsedError):
+    with pytest.raises(InternalFunctionUsedError):
         InternalStorage["key1"] = "value"
-    with pytest.raises(error.InternalFunctionUsedError):
+    with pytest.raises(InternalFunctionUsedError):
         InternalStorage["key1_"] = "value"
-    with pytest.raises(error.InternalFunctionUsedError):
+    with pytest.raises(InternalFunctionUsedError):
         InternalStorage["key__1"] = "value"
 
     InternalStorage["_key0"] = "value1"

--- a/src/test/i_storage_test.py
+++ b/src/test/i_storage_test.py
@@ -4,7 +4,11 @@
 
 import pytest
 
-from abllib.error import InternalFunctionUsedError, InvalidKeyError, KeyNotFoundError, SingletonInstantiationError, WrongTypeError
+from abllib.error import InternalFunctionUsedError, \
+                         InvalidKeyError, \
+                         KeyNotFoundError, \
+                         SingletonInstantiationError, \
+                         WrongTypeError
 from abllib._storage import _BaseStorage, _InternalStorage
 
 def test_basestorage_instantiation():


### PR DESCRIPTION
Add error handling for when invalid keys are used with any storage.

Keys are invalid if they are:
* not of type str
* leading with a dot ('.')
* ending with a dot ('.')
* containing two dots without something between them ('..')

Trying to use an invalid key raises an InvalidKeyError.