### PR TITLE
[alg] 10x speedup for levenshtein distance with optional C implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ To always install the latest development version:
 abllib @ git+https://github.com/Ableytner/abllib
 ```
 
+### Optional dependencies
+
+Some modules have optional dependencies which bring various improvements.
+All of them are optional and listed below.
+
+| name | needed in | improvement |
+|------|-----------|-------------|
+| pykakasi | fs.filename | needed to correctly translate japanese kanji |
+| levenshtein | alg.levenshtein_distance | provides a 10x speedup by using the C implementation |
+
 ## Documentation
 
 ### 1. Algorithms (`abllib.alg`)
@@ -85,6 +95,9 @@ Example usage:
 >> levenshtein_distance("thomas", "anna")
 5
 ```
+
+If the optional package 'Levenshtein' is installed (`pip install Levenshtein`), its C implementation is used instead.
+This provides a 10x speedup, but requires an extra package.
 
 ### 2. Errors (`abllib.error`)
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,9 @@ Special characters from unsupported languages and any other non-ascii will be re
 
 This module contains functions to search for strings within a list of strings, while applying [fuzzy searching logic](https://en.wikipedia.org/wiki/Approximate_string_matching).
 
+> [!TIP]
+> If the performance seems poor, the optional levenshtein package can be installed for a 10x speedup (`pip install levenshtein`).
+
 The source code and documentation use a few words which might be confusing, so they are explained here:
 * target: the word that we want to find.
 * candidate: a word that could match with target.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "abllib"
-version = "1.4.1rc1"
+version = "1.4.1rc2"
 authors = [
   { name="Ableytner", email="ableytner@gmx.at" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ dependencies = [
 
 [project.optional-dependencies]
 all = [
-  "pykakasi"
+  "pykakasi",
+  "levenshtein"
 ]
 dev = [
   "pylint",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 dill
 numpy
 pykakasi
+levenshtein
 pylint
 pytest

--- a/src/abllib/alg/__init__.py
+++ b/src/abllib/alg/__init__.py
@@ -1,6 +1,14 @@
 """A module containing general-purpose algorithms"""
 
-from ._levenshtein import levenshtein_distance
+from abllib.general import try_import_module
+
+Levenshtein = try_import_module("Levenshtein")
+
+if Levenshtein is None:
+    from ._levenshtein import levenshtein_distance
+else:
+    # use C implementation
+    levenshtein_distance = Levenshtein.distance
 
 __exports__ = [
     levenshtein_distance

--- a/src/test/alg_test.py
+++ b/src/test/alg_test.py
@@ -14,9 +14,9 @@ def test_levenshtein_distance():
 
     assert isinstance(alg.levenshtein_distance("dog", "god"), int)
 
-    with pytest.raises(error.WrongTypeError):
+    with pytest.raises((error.WrongTypeError, TypeError)):
         alg.levenshtein_distance("test", None)
-    with pytest.raises(error.WrongTypeError):
+    with pytest.raises((error.WrongTypeError, TypeError)):
         alg.levenshtein_distance(None, "test")
-    with pytest.raises(error.WrongTypeError):
+    with pytest.raises((error.WrongTypeError, TypeError)):
         alg.levenshtein_distance("test", 12)


### PR DESCRIPTION
## Description
Adds an optional depencendy `levenshtein` which implements the algorithm in C.
Using this implementation, the performance increases ~10x.

The dependency can be installed with `pip install levenshtein`

## Checklist before merging

* [x] applied `ready-to-merge` label
* [x] updated documentation ([README.md](../README.md))
* [x] updated version number ([pyproject.toml](../pyproject.toml))
