### PR TITLE
[MAINT] Unify formatting within the library

### DIFF
--- a/src/abllib/error/_general.py
+++ b/src/abllib/error/_general.py
@@ -1,10 +1,10 @@
 """Module containing custom exceptions for general usage"""
 
-# pylint: disable=arguments-differ
-
 from typing import Any
 
 from ._custom_exception import CustomException
+
+# pylint: disable=arguments-differ
 
 class ArgumentCombinationError(CustomException):
     """Exception raised when the given combination of arguments is invalid"""

--- a/src/abllib/general.py
+++ b/src/abllib/general.py
@@ -7,9 +7,9 @@ from types import ModuleType
 from abllib.error import MissingRequiredModuleError
 from abllib.log import get_logger
 
-logger = get_logger("general")
-
 # pylint: disable=raise-missing-from
+
+logger = get_logger("general")
 
 def try_import_module(module_name: str, error_msg: str | None = None, enforce: bool = False) -> ModuleType | None:
     """

--- a/src/abllib/pproc/_worker_process.py
+++ b/src/abllib/pproc/_worker_process.py
@@ -1,7 +1,5 @@
 """A module containing the WorkerProcess class"""
 
-# pylint: disable=dangerous-default-value
-
 from multiprocessing import Process, Queue
 from time import sleep
 from typing import Any
@@ -9,6 +7,8 @@ from typing import Any
 import dill
 
 from abllib.log import get_logger
+
+# pylint: disable=dangerous-default-value
 
 class WorkerProcess(Process):
     """Wrapper around `multiprocessing.Process` that stores and returns resulting values and exceptions."""

--- a/src/abllib/storage/_persistent_storage.py
+++ b/src/abllib/storage/_persistent_storage.py
@@ -1,7 +1,5 @@
 """Module containing the _PersistentStorage class"""
 
-# pylint: disable=protected-access
-
 import json
 import os
 from typing import Any
@@ -10,6 +8,8 @@ from abllib import error, fs, onexit
 from abllib._storage import InternalStorage
 from abllib.storage._storage_view import _StorageView
 from ._threadsafe_storage import _ThreadsafeStorage
+
+# pylint: disable=protected-access
 
 class _PersistentStorage(_ThreadsafeStorage):
     """Storage that persists across restarts"""

--- a/src/test/conftest.py
+++ b/src/test/conftest.py
@@ -1,5 +1,5 @@
 """
-    Pytest configuration
+Pytest configuration
 """
 
 # pylint: disable=wrong-import-position, wrong-import-order, missing-function-docstring

--- a/src/test/error_test.py
+++ b/src/test/error_test.py
@@ -1,10 +1,10 @@
 """Module containing tests for the different types of errors"""
 
-# pylint: disable=missing-class-docstring
-
 import pytest
 
 from abllib import error
+
+# pylint: disable=missing-class-docstring
 
 def test_customexception_inheritance():
     """Ensure that CustomException inherits from Exception"""

--- a/src/test/fixtures.py
+++ b/src/test/fixtures.py
@@ -1,8 +1,6 @@
 """
-    Pytest fixtures
+Pytest fixtures
 """
-
-# pylint: disable=protected-access, missing-class-docstring
 
 import os
 import shutil
@@ -10,6 +8,8 @@ import shutil
 import pytest
 
 from abllib import fs, log, storage, _storage, onexit
+
+# pylint: disable=protected-access
 
 logger = log.get_logger("test")
 
@@ -64,6 +64,7 @@ def capture_logs():
     yield None
 
     log.initialize()
+    log.add_console_handler()
     # file is created lazily
     if os.path.isfile("test.log"):
         os.remove("test.log")

--- a/src/test/fuzzy_test.py
+++ b/src/test/fuzzy_test.py
@@ -1,8 +1,8 @@
 """Module containing tests for the abllib.fuzzy module"""
 
-# pylint: disable=protected-access
-
 from abllib import fuzzy
+
+# pylint: disable=protected-access
 
 def test_all():
     """Ensure that fuzzy.match_all works at all"""

--- a/src/test/i_storage_test.py
+++ b/src/test/i_storage_test.py
@@ -1,7 +1,5 @@
 """Module containing tests for the different types of Storage"""
 
-# pylint: disable=protected-access, missing-class-docstring, pointless-statement, expression-not-assigned
-
 import pytest
 
 from abllib.error import InternalFunctionUsedError, \
@@ -12,6 +10,8 @@ from abllib.error import InternalFunctionUsedError, \
                          UninitializedFieldError, \
                          WrongTypeError
 from abllib._storage import _BaseStorage, _InternalStorage
+
+# pylint: disable=protected-access, missing-class-docstring, pointless-statement, expression-not-assigned
 
 def test_basestorage_instantiation():
     """Ensure that BaseStorage cannot be initialized"""

--- a/src/test/pproc_test.py
+++ b/src/test/pproc_test.py
@@ -1,7 +1,5 @@
 """Module containing tests for abllib.thread"""
 
-# pylint: disable=missing-class-docstring
-
 from multiprocessing import Process
 from threading import Thread
 from time import sleep
@@ -9,6 +7,8 @@ from time import sleep
 import pytest
 
 from abllib import pproc, wrapper
+
+# pylint: disable=missing-class-docstring
 
 def test_workerthread_inheritance():
     """Ensure that WorkerThread inherits from Thread"""

--- a/src/test/storage_test.py
+++ b/src/test/storage_test.py
@@ -1,7 +1,5 @@
 """Module containing tests for the different types of Storage"""
 
-# pylint: disable=protected-access, missing-class-docstring, pointless-statement, expression-not-assigned
-
 import json
 import os
 
@@ -10,6 +8,8 @@ import pytest
 from abllib import error, _storage
 from abllib.storage import _CacheStorage, _VolatileStorage, _PersistentStorage, _StorageView, _ThreadsafeStorage
 from abllib._storage._base_storage import _BaseStorage
+
+# pylint: disable=protected-access, missing-class-docstring, pointless-statement, expression-not-assigned
 
 def test_threadsafestorage_name_custom():
     """Ensure that custom storages need to overwrite _STORAGE_NAME"""

--- a/src/test/wrapper_deprecation_test.py
+++ b/src/test/wrapper_deprecation_test.py
@@ -1,10 +1,10 @@
 """Module containing tests for the abllib.wrapper.deprecated functionality"""
 
-# pylint: disable=function-redefined, consider-using-with, unused-argument, missing-class-docstring
-
 import pytest
 
 from abllib import error, wrapper
+
+# pylint: disable=function-redefined, consider-using-with, unused-argument, missing-class-docstring
 
 def test_callable():
     """Ensure that wrapper.deprecated is callable"""

--- a/src/test/wrapper_test.py
+++ b/src/test/wrapper_test.py
@@ -1,7 +1,5 @@
 """Module containing tests for the abllib.wrapper module"""
 
-# pylint: disable=function-redefined, consider-using-with, unused-argument
-
 import re
 import os
 from datetime import datetime
@@ -11,6 +9,8 @@ import pytest
 
 from abllib import error, wrapper, log
 from abllib.pproc import WorkerThread
+
+# pylint: disable=function-redefined, consider-using-with, unused-argument
 
 def test_lock():
     """Ensure that Lock works as expected"""


### PR DESCRIPTION
## Description
Unify all formatting within the library. This unifies the following:
* order in source files (module docstring, imports, pylint ignores, logger and constants, everything else)

## Checklist before merging
The following things are left to do:
* relative or absolute imports
* create style guide for future reference

* [ ] applied `ready-to-merge` label
* [ ] updated documentation ([README.md](../README.md))
* [ ] updated version number ([pyproject.toml](../pyproject.toml))
