### PR TITLE
[storage] Allow bytes type in PersistentStorage and correctly handle tuple / _AutoRemoveDict

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
   - id: isort
     name: isort (python)
 - repo: https://github.com/pycqa/pylint
-  rev: v3.3.8
+  rev: v4.0.2
   hooks:
   - id: pylint
     args:

--- a/README.md
+++ b/README.md
@@ -713,6 +713,7 @@ It can only hold values of the following types:
 * int
 * float
 * str
+* bytes
 * list
 * dict
 * tuple

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "abllib"
-version = "1.4.3rc2"
+version = "1.4.4rc1"
 authors = [
   { name="Ableytner", email="ableytner@gmx.at" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "abllib"
-version = "1.4.3rc1"
+version = "1.4.3rc2"
 authors = [
   { name="Ableytner", email="ableytner@gmx.at" },
 ]

--- a/src/test/storage_test.py
+++ b/src/test/storage_test.py
@@ -144,21 +144,29 @@ def test_persistentstorage_valuetype():
     PersistentStorage._store = {}
 
     PersistentStorage["key1"] = True
+    PersistentStorage["key2"] = 10
+    PersistentStorage["key3"] = 10.1
+    PersistentStorage["key4"] = "value"
+    PersistentStorage["key5"] = ["1", "2"]
+    PersistentStorage["key6"] = {"key": "item"}
+    PersistentStorage["key7"] = None
+    PersistentStorage["key8"] = b"bytes work as well"
+    PersistentStorage["key9"] = "b64test"
+    PersistentStorage["key10"] = ("1", "2")
+
+    PersistentStorage.save_to_disk()
+    PersistentStorage.load_from_disk()
+
     assert PersistentStorage["key1"] is True
-    PersistentStorage["key1"] = 10
-    assert PersistentStorage["key1"] == 10
-    PersistentStorage["key1"] = 10.1
-    assert PersistentStorage["key1"] == 10.1
-    PersistentStorage["key1"] = "value"
-    assert PersistentStorage["key1"] == "value"
-    PersistentStorage["key1"] = ["1", "2"]
-    assert PersistentStorage["key1"] == ["1", "2"]
-    PersistentStorage["key1"] = {"key": "item"}
-    assert PersistentStorage["key1"] == {"key": "item"}
-    PersistentStorage["key1"] = ("1", "2")
-    assert PersistentStorage["key1"] == ("1", "2")
-    PersistentStorage["key1"] = None
-    assert PersistentStorage["key1"] is None
+    assert PersistentStorage["key2"] == 10
+    assert PersistentStorage["key3"] == 10.1
+    assert PersistentStorage["key4"] == "value"
+    assert PersistentStorage["key5"] == ["1", "2"]
+    assert PersistentStorage["key6"] == {"key": "item"}
+    assert PersistentStorage["key7"] is None
+    assert PersistentStorage["key8"] == b"bytes work as well"
+    assert PersistentStorage["key9"] == "b64test"
+    assert PersistentStorage["key10"] == ("1", "2")
 
     class CustomType():
         pass
@@ -211,7 +219,10 @@ def test_persistentstorage_save_file():
     with open(filepath, "r", encoding="utf8") as f:
         data = json.load(f)
     assert data["key1"] == "value"
-    assert data["key2"] == ["value21", "value22", "value23"]
+    assert data["key2"] == {
+        "_t": "list",
+        "_v": ["value21", "value22", "value23"]
+    }
     assert data["key4"] == 10
 
     os.remove(filepath)

--- a/src/test/storage_test.py
+++ b/src/test/storage_test.py
@@ -6,7 +6,7 @@ import os
 import pytest
 
 from abllib import _storage, error
-from abllib._storage._base_storage import _BaseStorage
+from abllib._storage._base_storage import _AutoremoveDict, _BaseStorage
 from abllib.storage import (_CacheStorage, _PersistentStorage, _StorageView,
                             _ThreadsafeStorage, _VolatileStorage)
 
@@ -153,6 +153,8 @@ def test_persistentstorage_valuetype():
     PersistentStorage["key8"] = b"bytes work as well"
     PersistentStorage["key9"] = "b64test"
     PersistentStorage["key10"] = ("1", "2")
+    PersistentStorage["key11.1"] = "subvalue"
+    PersistentStorage["key12.1.2.3.4.5.6.7.8.9"] = "subsubvalue"
 
     PersistentStorage.save_to_disk()
     PersistentStorage.load_from_disk()
@@ -167,6 +169,9 @@ def test_persistentstorage_valuetype():
     assert PersistentStorage["key8"] == b"bytes work as well"
     assert PersistentStorage["key9"] == "b64test"
     assert PersistentStorage["key10"] == ("1", "2")
+    assert isinstance(PersistentStorage["key11"], _AutoremoveDict)
+    assert PersistentStorage["key11.1"] == "subvalue"
+    assert PersistentStorage["key12.1.2.3.4.5.6.7.8.9"] == "subsubvalue"
 
     class CustomType():
         pass


### PR DESCRIPTION
## Description
The format in which PersistentStorage data is stored has changed to include the original datatype.

These changes are backwards compatible, old data will be converted in the first program start.

## Checklist before merging

* [x] applied `ready-to-merge` label
* [x] updated documentation ([README.md](../README.md))
* [x] incremented version number ([pyproject.toml](../pyproject.toml))
