### PR TITLE
[enum] Add enum module

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,16 @@ It is structured into small submodules, which are all optional and not dependent
 
 The following submodules are available:
 1. Algorithms (`abllib.alg`)
-2. Errors (`abllib.error`)
-3. File system operations (`abllib.fs`)
-4. Fuzzy matching (`abllib.fuzzy`)
-5. General (`abllib.general`)
-6. Logging (`abllib.log`)
-7. Cleanup on exit (`abllib.onexit`)
-8. Parallel processing (`abllib.pproc`)
-9. Storages (`abllib.storage`)
-10. Function wrappers (`abllib.wrapper`)
+2. Enum (`abllib.enum`)
+3. Errors (`abllib.error`)
+4. File system operations (`abllib.fs`)
+5. Fuzzy matching (`abllib.fuzzy`)
+6. General (`abllib.general`)
+7. Logging (`abllib.log`)
+8. Cleanup on exit (`abllib.onexit`)
+9. Parallel processing (`abllib.pproc`)
+10. Storages (`abllib.storage`)
+11. Function wrappers (`abllib.wrapper`)
 
 ## Installation
 
@@ -34,9 +35,9 @@ This will automatically install all other dependencies.
 
 Alternatively, a specific version can be installed as follows:
 ```bash
-pip install abllib==1.3.6
+pip install abllib==1.4.3
 ```
-where 1.3.6 is the version you want to install.
+where 1.4.3 is the version you want to install.
 
 ### Github
 
@@ -51,9 +52,9 @@ Additionally, a [wheel](https://peps.python.org/pep-0427/) is added to every [st
 
 If you want to include this library as a dependency in your requirements.txt, the syntax is as follows:
 ```text
-abllib==1.3.6
+abllib==1.4.3
 ```
-where 1.3.6 is the version that you want to install.
+where 1.4.3 is the version that you want to install.
 
 To always use the latest stable version:
 ```text
@@ -99,7 +100,51 @@ Example usage:
 If the optional package 'Levenshtein' is installed (`pip install Levenshtein`), its C implementation is used instead.
 This provides a 10x speedup, but requires an extra package.
 
-### 2. Errors (`abllib.error`)
+### 2. Enum (`abllib.enum`)
+
+This module contains `abllib.enum.Enum`, an extended implementation of the builtin `enum.Enum`.
+
+#### CustomException (`abllib.enum.Enum`)
+
+An extended implementation of the Python-builtin `enum.Enum`, which supports more comparison operations and provides convenience functions.
+
+Enums are still defined exactly the same when using this class
+```py
+>> from abllib.enum import Enum
+>> class Animal(Enum):
+..     DOG = 0
+..     CAT = 1
+..     BIRD = 2
+```
+
+A major difference is that enums can now be correctly compared with its value.
+```py
+>> Animal.DOG == 0
+True
+>> 2 == Animal.BIRD
+True
+```
+
+Enums are now also hashable, which allows them to be used better when checking list contents:
+```py
+>> 0 in [Animal.CAT, Animal.BIRD]
+False
+>> 1 in [Animal.CAT, Animal.BIRD]
+TRUE
+>> Animal.BIRD in [0, 2]
+TRUE
+```
+
+Two convenience methods, `from_name` and `from_value`, have also been added:
+```py
+>> MyEnum.from_name("BIRD") is MyEnum.BIRD
+True
+>> MyEnum.from_value(1) is myEnum.CAT
+TRUE
+```
+Note however that `from_name` is **case-sensitive**!
+
+### 3. Errors (`abllib.error`)
 
 This module contains a custom exception system, which supports default messages for different errors.
 
@@ -153,7 +198,7 @@ This module also contains some premade general-purpose error classes, which all 
 * UninitializedFieldError
 * WrongTypeError
 
-### 3. File system (`abllib.fs`)
+### 4. File system (`abllib.fs`)
 
 This module contains various file system-related functionality. All provided functions are tested and work correctly on Linux and Windows systems.
 
@@ -201,7 +246,7 @@ Currently supported language-specific text transliterations:
 
 Special characters from unsupported languages and any other non-ascii will be removed from the resulting text.
 
-### 4. Fuzzy matching (`abllib.fuzzy`)
+### 5. Fuzzy matching (`abllib.fuzzy`)
 
 This module contains functions to search for strings within a list of strings, while applying [fuzzy searching logic](https://en.wikipedia.org/wiki/Approximate_string_matching).
 
@@ -315,7 +360,7 @@ Example usage:
 1.0
 ```
 
-### 5. General (`abllib.general`)
+### 6. General (`abllib.general`)
 
 This module contains different general-purpose functions that don't warrant an own module.
 
@@ -355,7 +400,7 @@ Traceback (most recent call last):
 abllib.error._general.MissingRequiredModuleError: "The error message"
 ```
 
-### 6. Logging (`abllib.log`)
+### 7. Logging (`abllib.log`)
 
 This module contains functions to easily log to the console or specified log files.
 It can be used without initialization, or customized.
@@ -469,7 +514,7 @@ Code in the application which runs later:
 
 This results in a final setup which writes to mylogfile.txt and doesn't produce console output.
 
-### 7. Cleanup on exit (`abllib.onexit`)
+### 8. Cleanup on exit (`abllib.onexit`)
 
 This module contains functions to register callbacks which run on application exit.
 
@@ -507,7 +552,7 @@ Already registered callbacks can also be deregistered:
 >> exit()
 ```
 
-### 8. Parallel processing (`abllib.pproc`)
+### 9. Parallel processing (`abllib.pproc`)
 
 This module contains parallel processing-related functionality, both thread-based and process-based.
 
@@ -615,7 +660,7 @@ Traceback (most recent call last):
 ValueError: The answer is not yet calculated!
 ```
 
-### 9. Storages (`abllib.storage`)
+### 10. Storages (`abllib.storage`)
 
 This module contains multiple storage types.
 All data stored in these storages is accessible from anywhere within the program, as each storage is a global [singleton](https://en.wikipedia.org/wiki/Singleton_pattern).
@@ -962,7 +1007,7 @@ True
 True
 ```
 
-### 10. Function wrappers (`abllib.wrapper`)
+### 11. Function wrappers (`abllib.wrapper`)
 
 This module contains general-purpose [wrappers](https://www.geeksforgeeks.org/function-wrappers-in-python/).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "abllib"
-version = "1.4.4rc3"
+version = "1.4.4rc4"
 authors = [
   { name="Ableytner", email="ableytner@gmx.at" },
 ]

--- a/src/abllib/__init__.py
+++ b/src/abllib/__init__.py
@@ -4,7 +4,7 @@ Ableytner's library for Python
 Contains many general-purpose functions which can be used across projects.
 """
 
-from abllib import (alg, error, fs, fuzzy, general, log, onexit, pproc,
+from abllib import (alg, enum, error, fs, fuzzy, general, log, onexit, pproc,
                     storage, wrapper)
 from abllib.general import try_import_module
 from abllib.log import LogLevel, get_logger
@@ -14,6 +14,7 @@ from abllib.wrapper import Lock, NamedLock, NamedSemaphore, Semaphore
 
 __exports__ = [
     alg,
+    enum,
     error,
     fs,
     fuzzy,

--- a/src/abllib/enum.py
+++ b/src/abllib/enum.py
@@ -1,0 +1,33 @@
+"""A module containing an improved Enum implementation"""
+
+from __future__ import annotations
+
+from enum import Enum as OriginalEnum
+from typing import Any
+
+class Enum(OriginalEnum):
+    """An improved Enum implementation"""
+
+    # allow comparing Enum objects and values directly
+    def __eq__(self, other: object) -> bool:
+        return self is other or self.value == other
+
+    def __ne__(self, other: object) -> bool:
+        return self is not other and self.value != other
+
+    # for more details look here:
+    # https://stackoverflow.com/a/72664895/15436169
+    def __hash__(self) -> int:
+        return hash(self.value)
+
+    @classmethod
+    def from_name(cls, name: Any) -> Enum:
+        """Return the Enum corresponding to the given name"""
+
+        return cls[name]
+
+    @classmethod
+    def from_value(cls, value: Any) -> Enum:
+        """Return the Enum corresponding to the given value"""
+
+        return cls(value)

--- a/src/abllib/fs/filename.py
+++ b/src/abllib/fs/filename.py
@@ -4,6 +4,7 @@ from abllib.error import MissingRequiredModuleError, WrongTypeError
 from abllib.general import try_import_module
 from abllib.log import get_logger
 
+# optional module for japanese character transliterating
 pykakasi = try_import_module("pykakasi")
 
 logger = get_logger("sanitize")

--- a/src/abllib/general.py
+++ b/src/abllib/general.py
@@ -23,7 +23,6 @@ def try_import_module(module_name: str, error_msg: str | None = None, enforce: b
     module = None
 
     try:
-        # optional module for japanese character transliterating
         module = importlib.import_module(module_name)
         sys.modules[module_name] = module
     except ImportError:

--- a/src/abllib/log.py
+++ b/src/abllib/log.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import atexit
 import logging
 import sys
-from enum import Enum
 from typing import Literal
 
 from abllib import error
 from abllib._storage import InternalStorage
+from abllib.enum import Enum
 
 DEFAULT_LOG_LEVEL = logging.INFO
 CURRENT_LOG_LEVEL_CACHE = None
@@ -47,17 +47,6 @@ class LogLevel(Enum):
                 return LogLevel.CRITICAL
             case _:
                 raise error.NameNotFoundError(f"'{log_level}' isn't a known log level")
-
-    def __eq__(self, other: object) -> bool:
-        return self is other or self.value == other
-
-    def __ne__(self, other: object) -> bool:
-        return self is not other and self.value != other
-
-    # for more details look here:
-    # https://stackoverflow.com/a/72664895/15436169
-    def __hash__(self) -> int:
-        return hash(self.value)
 
 def initialize(log_level: Literal[LogLevel.CRITICAL]
                           | Literal[LogLevel.ERROR]

--- a/src/test/enum_test.py
+++ b/src/test/enum_test.py
@@ -48,7 +48,7 @@ def test_comparison():
 def test_hashable():
     """Ensure that enum objects are hashable"""
 
-    class MyEnum(original_enum.Enum):
+    class MyEnum(enum.Enum):
         TRUE = 1
         FALSE = 0
 

--- a/src/test/enum_test.py
+++ b/src/test/enum_test.py
@@ -1,0 +1,83 @@
+"""Module containing tests for the abllib.enum module"""
+
+import enum as original_enum
+
+from abllib import enum
+
+# pylint: disable=missing-class-docstring
+
+def test_create():
+    """Ensure that a basic deriving Enum class works as expected"""
+
+    class MyEnum(enum.Enum):
+        TRUE = 1
+        FALSE = 0
+
+    assert issubclass(MyEnum, original_enum.Enum)
+    assert issubclass(MyEnum, enum.Enum)
+    assert isinstance(MyEnum.TRUE, original_enum.Enum)
+    assert isinstance(MyEnum.FALSE, original_enum.Enum)
+
+    assert MyEnum.TRUE.value == 1
+    assert MyEnum.FALSE.value == 0
+    assert MyEnum.TRUE.value != MyEnum.FALSE.value
+
+def test_comparison():
+    """Ensure that the new comparisons work as expected"""
+
+    class MyEnum(enum.Enum):
+        TRUE = 1
+        FALSE = 0
+
+    assert MyEnum.TRUE == 1
+    assert MyEnum.FALSE == 0
+    assert 1 == MyEnum.TRUE
+    assert 0 == MyEnum.FALSE
+
+    assert MyEnum.TRUE != 0
+    assert MyEnum.FALSE != 1
+    assert 0 != MyEnum.TRUE
+    assert 1 != MyEnum.FALSE
+
+    assert MyEnum.TRUE == MyEnum.TRUE
+    assert MyEnum.FALSE == MyEnum.FALSE
+
+    assert MyEnum.TRUE != MyEnum.FALSE
+    assert MyEnum.FALSE != MyEnum.TRUE
+
+def test_hashable():
+    """Ensure that enum objects are hashable"""
+
+    class MyEnum(original_enum.Enum):
+        TRUE = 1
+        FALSE = 0
+
+    assert 1 in [MyEnum.TRUE]
+    assert 1 not in [MyEnum.FALSE]
+    assert 0 in [MyEnum.FALSE]
+    assert 0 not in [MyEnum.TRUE]
+
+    assert MyEnum.TRUE in [1]
+    assert MyEnum.TRUE not in [0]
+    assert MyEnum.FALSE in [0]
+    assert MyEnum.FALSE not in [1]
+
+def test_from_name():
+    """Ensure that Enum.from_name works as expected"""
+
+    class MyEnum(enum.Enum):
+        TRUE = 1
+        FALSE = 0
+
+    assert MyEnum.from_name("TRUE") is MyEnum.TRUE
+    assert MyEnum.from_name("FALSE") is MyEnum.FALSE
+
+def test_from_value():
+    """Ensure that Enum.from_value works as expected"""
+
+    class MyEnum(enum.Enum):
+        TRUE = 1
+        FALSE = 0
+
+    assert MyEnum.from_value(1) is MyEnum.TRUE
+    assert MyEnum.from_value(0) is MyEnum.FALSE


### PR DESCRIPTION
## Description

This PR adds a new `abllib.enum.Enum` class, which is a drop-in replacement for the builtin `enum.Enum`.

## Checklist before merging

* [x] applied `ready-to-merge` label
* [x] updated documentation ([README.md](../README.md))
* [x] incremented version number ([pyproject.toml](../pyproject.toml))
