### PR TITLE
[fs] Resolve ~ to current user home path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "abllib"
-version = "1.4.4rc4"
+version = "1.4.4rc5"
 authors = [
   { name="Ableytner", email="ableytner@gmx.at" },
 ]

--- a/src/abllib/fs/path.py
+++ b/src/abllib/fs/path.py
@@ -11,15 +11,20 @@ def absolute(*paths: str | pathlib.Path) -> str:
     Additionally, the path is resolved, removing any symlinks on the way.
     """
 
-    if len(paths) == 0:
+    paths_list = list(paths)
+
+    if len(paths_list) == 0:
         raise ValueError()
-    for item in paths:
+    for item in paths_list:
         if not isinstance(item, (str, pathlib.Path)):
             raise WrongTypeError().with_values(item, (str, pathlib.Path))
 
-    path = pathlib.Path(*paths)
+    if isinstance(paths_list[0], str):
+        if paths_list[0] == "~":
+            paths_list[0] = pathlib.Path.home()
+        elif paths_list[0].startswith("~/"):
+            paths_list[0] = paths_list[0].replace("~", str(pathlib.Path.home()), count=1)
 
-    if path.is_absolute():
-        return str(path.resolve())
+    path = pathlib.Path(*paths_list)
 
     return str(path.absolute().resolve())

--- a/src/abllib/fs/path.py
+++ b/src/abllib/fs/path.py
@@ -23,7 +23,7 @@ def absolute(*paths: str | pathlib.Path) -> str:
         if paths_list[0] == "~":
             paths_list[0] = pathlib.Path.home()
         elif paths_list[0].startswith("~/"):
-            paths_list[0] = paths_list[0].replace("~", str(pathlib.Path.home()), count=1)
+            paths_list[0] = paths_list[0].replace("~", str(pathlib.Path.home()), 1)
 
     path = pathlib.Path(*paths_list)
 

--- a/src/test/fs_test.py
+++ b/src/test/fs_test.py
@@ -21,6 +21,10 @@ def test_absolute():
     assert fs.absolute("subdir", pathlib.Path("another"), "test.txt") \
            == os.path.join(_uppercase_path(os.getcwd()), "subdir", "another", "test.txt")
     assert fs.absolute("subdir", "..", "test.txt") == os.path.join(_uppercase_path(os.getcwd()), "test.txt")
+    assert fs.absolute("~/", "test.txt") == os.path.join(pathlib.Path.home(), "test.txt")
+    assert fs.absolute("~", "test.txt") == os.path.join(pathlib.Path.home(), "test.txt")
+    # pylint: disable-next=line-too-long
+    assert fs.absolute("~/subdir/another/test.txt") == os.path.join(pathlib.Path.home(), "subdir", "another", "test.txt")
 
     with pytest.raises(WrongTypeError):
         fs.absolute(None)


### PR DESCRIPTION
## Description

Correctly resolve paths like `~/.ssh` in `abllib.fs.absolute`.

## Checklist before merging

* [x] applied `ready-to-merge` label
* [x] updated documentation ([README.md](../README.md))
* [x] incremented version number ([pyproject.toml](../pyproject.toml))
