### PR TITLE
[convert] Add abllib.convert module

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ Example:
 >> from abllib import convert
 >> convert.as_time(17.4163)
 '17.4s'
->> convert.as_bytes(86000)
+>> convert.as_time(86000)
 '23.9h'
->> convert.as_bytes(1 * (10 ** 9))
+>> convert.as_time(1 * (10 ** 9))
 '31.7y'
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,16 +12,17 @@ It is structured into small submodules, which are all optional and not dependent
 
 The following submodules are available:
 1. Algorithms (`abllib.alg`)
-2. Enum (`abllib.enum`)
-3. Errors (`abllib.error`)
-4. File system operations (`abllib.fs`)
-5. Fuzzy matching (`abllib.fuzzy`)
-6. General (`abllib.general`)
-7. Logging (`abllib.log`)
-8. Cleanup on exit (`abllib.onexit`)
-9. Parallel processing (`abllib.pproc`)
-10. Storages (`abllib.storage`)
-11. Function wrappers (`abllib.wrapper`)
+2. Converters (`abllib.convert`)
+3. Enum (`abllib.enum`)
+4. Errors (`abllib.error`)
+5. File system operations (`abllib.fs`)
+6. Fuzzy matching (`abllib.fuzzy`)
+7. General (`abllib.general`)
+8. Logging (`abllib.log`)
+9. Cleanup on exit (`abllib.onexit`)
+10. Parallel processing (`abllib.pproc`)
+11. Storages (`abllib.storage`)
+12. Function wrappers (`abllib.wrapper`)
 
 ## Installation
 
@@ -100,7 +101,37 @@ Example usage:
 If the optional package 'Levenshtein' is installed (`pip install Levenshtein`), its C implementation is used instead.
 This provides a 10x speedup, but requires an extra package.
 
-### 2. Enum (`abllib.enum`)
+### 2. Converters (`abllib.convert`)
+
+This module contains converters between raw data and human-readable formats.
+
+#### Bytes to human-readable format (`abllib.convert.as_bytes`)
+
+This function converts a number (in bytes) to human-readable format.
+
+Example:
+```py
+>> from abllib import convert
+>> convert.as_bytes(12700)
+'12.7kB'
+>> convert.as_bytes(1000**4)
+'1.0TB'
+```
+
+#### Bytes representation to number (`abllib.convert.get_bytes`)
+
+This function converts a bytes representation to a number (in bytes).
+
+Example:
+```py
+>> from abllib import convert
+>> convert.get_bytes("16.2MB")
+16200000000
+>> convert.get_bytes("251b")
+251
+```
+
+### 3. Enum (`abllib.enum`)
 
 This module contains `abllib.enum.Enum`, an extended implementation of the builtin `enum.Enum`.
 
@@ -144,7 +175,7 @@ TRUE
 ```
 Note however that `from_name` is **case-sensitive**!
 
-### 3. Errors (`abllib.error`)
+### 4. Errors (`abllib.error`)
 
 This module contains a custom exception system, which supports default messages for different errors.
 
@@ -198,7 +229,7 @@ This module also contains some premade general-purpose error classes, which all 
 * UninitializedFieldError
 * WrongTypeError
 
-### 4. File system (`abllib.fs`)
+### 5. File system (`abllib.fs`)
 
 This module contains various file system-related functionality. All provided functions are tested and work correctly on Linux and Windows systems.
 
@@ -246,7 +277,7 @@ Currently supported language-specific text transliterations:
 
 Special characters from unsupported languages and any other non-ascii will be removed from the resulting text.
 
-### 5. Fuzzy matching (`abllib.fuzzy`)
+### 6. Fuzzy matching (`abllib.fuzzy`)
 
 This module contains functions to search for strings within a list of strings, while applying [fuzzy searching logic](https://en.wikipedia.org/wiki/Approximate_string_matching).
 
@@ -360,7 +391,7 @@ Example usage:
 1.0
 ```
 
-### 6. General (`abllib.general`)
+### 7. General (`abllib.general`)
 
 This module contains different general-purpose functions that don't warrant an own module.
 
@@ -400,7 +431,7 @@ Traceback (most recent call last):
 abllib.error._general.MissingRequiredModuleError: "The error message"
 ```
 
-### 7. Logging (`abllib.log`)
+### 8. Logging (`abllib.log`)
 
 This module contains functions to easily log to the console or specified log files.
 It can be used without initialization, or customized.
@@ -514,7 +545,7 @@ Code in the application which runs later:
 
 This results in a final setup which writes to mylogfile.txt and doesn't produce console output.
 
-### 8. Cleanup on exit (`abllib.onexit`)
+### 9. Cleanup on exit (`abllib.onexit`)
 
 This module contains functions to register callbacks which run on application exit.
 
@@ -552,7 +583,7 @@ Already registered callbacks can also be deregistered:
 >> exit()
 ```
 
-### 9. Parallel processing (`abllib.pproc`)
+### 10. Parallel processing (`abllib.pproc`)
 
 This module contains parallel processing-related functionality, both thread-based and process-based.
 
@@ -660,7 +691,7 @@ Traceback (most recent call last):
 ValueError: The answer is not yet calculated!
 ```
 
-### 10. Storages (`abllib.storage`)
+### 11. Storages (`abllib.storage`)
 
 This module contains multiple storage types.
 All data stored in these storages is accessible from anywhere within the program, as each storage is a global [singleton](https://en.wikipedia.org/wiki/Singleton_pattern).
@@ -1007,7 +1038,7 @@ True
 True
 ```
 
-### 11. Function wrappers (`abllib.wrapper`)
+### 12. Function wrappers (`abllib.wrapper`)
 
 This module contains general-purpose [wrappers](https://www.geeksforgeeks.org/function-wrappers-in-python/).
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,23 @@ This provides a 10x speedup, but requires an extra package.
 
 This module contains converters between raw data and human-readable formats.
 
+#### Seconds to human-readable format (`abllib.convert.as_time`)
+
+This function converts a number (in seconds) to human-readable format.
+
+Leap years are assumed to happen every 4 years, so years not divisible by 4 may be slightly off.
+
+Example:
+```py
+>> from abllib import convert
+>> convert.as_time(17.4163)
+'17.4s'
+>> convert.as_bytes(86000)
+'23.9h'
+>> convert.as_bytes(1 * (10 ** 9))
+'31.7y'
+```
+
 #### Bytes to human-readable format (`abllib.convert.as_bytes`)
 
 This function converts a number (in bytes) to human-readable format.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "abllib"
-version = "1.4.4rc5"
+version = "1.4.5rc1"
 authors = [
   { name="Ableytner", email="ableytner@gmx.at" },
 ]

--- a/src/abllib/__init__.py
+++ b/src/abllib/__init__.py
@@ -4,8 +4,8 @@ Ableytner's library for Python
 Contains many general-purpose functions which can be used across projects.
 """
 
-from abllib import (alg, enum, error, fs, fuzzy, general, log, onexit, pproc,
-                    storage, wrapper)
+from abllib import (alg, convert, enum, error, fs, fuzzy, general, log, onexit,
+                    pproc, storage, wrapper)
 from abllib.general import try_import_module
 from abllib.log import LogLevel, get_logger
 from abllib.storage import (CacheStorage, PersistentStorage, StorageView,
@@ -14,6 +14,7 @@ from abllib.wrapper import Lock, NamedLock, NamedSemaphore, Semaphore
 
 __exports__ = [
     alg,
+    convert,
     enum,
     error,
     fs,

--- a/src/abllib/convert.py
+++ b/src/abllib/convert.py
@@ -1,5 +1,7 @@
 """A module containing formatting functions"""
 
+from typing import TypeVar
+
 from abllib.error import WrongTypeError
 
 PREFIXES = {
@@ -31,6 +33,7 @@ def as_time(value: int | float) -> str:
 
     if not isinstance(value, (int, float)):
         raise WrongTypeError.with_values(value, (int, float))
+    _ensure_positive_value(value)
 
     if value < 1:
         return f"{_append_si_prefix(value)}s"
@@ -59,6 +62,7 @@ def as_bytes(value: int | float) -> str:
 
     if not isinstance(value, (int, float)):
         raise WrongTypeError.with_values(value, (int, float))
+    _ensure_positive_value(value)
 
     return f"{_append_si_prefix(value)}B"
 
@@ -69,12 +73,15 @@ def get_bytes(text: str) -> int:
         raise WrongTypeError.with_values(text, str)
 
     if text.isdigit():
-        return int(text)
+        return _ensure_positive_value(int(text))
 
     if text[-1].lower() == "b":
         text = text[:-1]
         if text.isdigit():
-            return int(text)
+            return _ensure_positive_value(int(text))
+
+    if text[-1].isdigit():
+        return _ensure_positive_value(int(float(text)))
 
     number = float(text[:-1])
     multiplier = text[-1].upper()
@@ -91,12 +98,12 @@ def get_bytes(text: str) -> int:
         case _:
             raise ValueError(f"Unknown SI prefix {multiplier} in {text}")
 
-    return int(number)
+    return _ensure_positive_value(int(number))
 
 def _append_si_prefix(value: int | float) -> str:
     bases_changed = 0
 
-    while value < 1 or value >= 1000:
+    while value != 0 and (value < 1 or value >= 1000):
         if value < 1:
             bases_changed -= 3
             value *= 1000
@@ -105,3 +112,11 @@ def _append_si_prefix(value: int | float) -> str:
             value /= 1000
 
     return f"{value:.1f}{PREFIXES[str(bases_changed)]}"
+
+T = TypeVar('T', int, float)
+
+def _ensure_positive_value(value: T) -> T:
+    if value < 0:
+        raise ValueError(f"expected value >= 0, but received '{value}'")
+
+    return value

--- a/src/abllib/convert.py
+++ b/src/abllib/convert.py
@@ -26,6 +26,34 @@ PREFIXES = {
     "30": "Q"
 }
 
+def as_time(value: int | float) -> str:
+    """Format the given number of seconds to a human-readable format"""
+
+    if not isinstance(value, (int, float)):
+        raise WrongTypeError.with_values(value, (int, float))
+
+    if value < 1:
+        return f"{_append_si_prefix(value)}s"
+
+    if value < 60:
+        return f"{value:.1f}s"
+    value /= 60
+
+    if value < 60:
+        return f"{value:.1f}min"
+    value /= 60
+
+    if value < 24:
+        return f"{value:.1f}h"
+    value /= 24
+
+    if value < 365:
+        return f"{value:.1f}d"
+    # a leap year every 4 years, this guess is good enough
+    value /= 365.25
+
+    return f"{value:.1f}y"
+
 def as_bytes(value: int | float) -> str:
     """Format the given number of bytes to a human-readable format"""
 

--- a/src/abllib/convert.py
+++ b/src/abllib/convert.py
@@ -1,0 +1,79 @@
+"""A module containing formatting functions"""
+
+from abllib.error import WrongTypeError
+
+PREFIXES = {
+    "-30": "q",
+    "-27": "r",
+    "-24": "y",
+    "-21": "z",
+    "-18": "a",
+    "-15": "f",
+    "-12": "p",
+    "-9": "n",
+    "-6": "μ",
+    "-3": "m",
+    "0": "",
+    "3": "k",
+    "6": "M",
+    "9": "G",
+    "12": "T",
+    "15": "P",
+    "18": "E",
+    "21": "Z",
+    "24": "Y",
+    "27": "R",
+    "30": "Q"
+}
+
+def as_bytes(value: int | float) -> str:
+    """Format the given number of bytes to a human-readable format"""
+
+    if not isinstance(value, (int, float)):
+        raise WrongTypeError.with_values(value, (int, float))
+
+    return f"{_append_si_prefix(value)}B"
+
+def get_bytes(text: str) -> int:
+    """Undo any formatting and return the number of bytes"""
+
+    if not isinstance(text, str):
+        raise WrongTypeError.with_values(text, str)
+
+    if text.isdigit():
+        return int(text)
+
+    if text[-1].lower() == "b":
+        text = text[:-1]
+        if text.isdigit():
+            return int(text)
+
+    number = float(text[:-1])
+    multiplier = text[-1].upper()
+
+    match multiplier:
+        case "T":
+            number *= 1000**4
+        case "G":
+            number *= 1000**3
+        case "M":
+            number *= 1000**2
+        case "K":
+            number *= 1000**1
+        case _:
+            raise ValueError(f"Unknown SI prefix {multiplier} in {text}")
+
+    return int(number)
+
+def _append_si_prefix(value: int | float) -> str:
+    bases_changed = 0
+
+    while value < 1 or value >= 1000:
+        if value < 1:
+            bases_changed -= 3
+            value *= 1000
+        else:
+            bases_changed += 3
+            value /= 1000
+
+    return f"{value:.1f}{PREFIXES[str(bases_changed)]}"

--- a/src/abllib/convert.py
+++ b/src/abllib/convert.py
@@ -3,29 +3,32 @@
 from typing import TypeVar
 
 from abllib.error import WrongTypeError
+from abllib.log import get_logger
+
+logger = get_logger("convert")
 
 PREFIXES = {
-    "-30": "q",
-    "-27": "r",
-    "-24": "y",
-    "-21": "z",
-    "-18": "a",
-    "-15": "f",
-    "-12": "p",
-    "-9": "n",
-    "-6": "μ",
-    "-3": "m",
-    "0": "",
-    "3": "k",
-    "6": "M",
-    "9": "G",
-    "12": "T",
-    "15": "P",
-    "18": "E",
-    "21": "Z",
-    "24": "Y",
-    "27": "R",
-    "30": "Q"
+    -30: "q",
+    -27: "r",
+    -24: "y",
+    -21: "z",
+    -18: "a",
+    -15: "f",
+    -12: "p",
+    -9: "n",
+    -6: "μ",
+    -3: "m",
+    0: "",
+    3: "k",
+    6: "M",
+    9: "G",
+    12: "T",
+    15: "P",
+    18: "E",
+    21: "Z",
+    24: "Y",
+    27: "R",
+    30: "Q"
 }
 
 def as_time(value: int | float) -> str:
@@ -111,7 +114,7 @@ def _append_si_prefix(value: int | float) -> str:
             bases_changed += 3
             value /= 1000
 
-    return f"{value:.1f}{PREFIXES[str(bases_changed)]}"
+    return f"{value:.1f}{PREFIXES[bases_changed]}"
 
 T = TypeVar('T', int, float)
 

--- a/src/abllib/wrapper/_timeit.py
+++ b/src/abllib/wrapper/_timeit.py
@@ -4,6 +4,7 @@ import functools
 from time import perf_counter_ns
 from typing import Any, Callable
 
+from abllib import convert
 from abllib.log import LogLevel
 from abllib.wrapper._base_log_wrapper import BaseLogWrapper
 
@@ -32,32 +33,8 @@ class timeit(BaseLogWrapper):
             res = func(*args, **kwargs)
 
             elapsed = float(perf_counter_ns() - start)
-
-            log_msg = f"{func.__name__}: "
-
-            for unit in ["ns", "μs", "ms"]:
-                if elapsed < 1000:
-                    log_msg += f"{elapsed:3.2f} {unit} elapsed"
-                    self.log(log_msg, LogLevel.DEBUG)
-                    return res
-
-                elapsed /= 1000
-
-            for unit in ["s", "min"]:
-                if elapsed < 60:
-                    log_msg += f"{elapsed:2.2f} {unit} elapsed"
-                    self.log(log_msg, LogLevel.DEBUG)
-                    return res
-
-                elapsed /= 60
-
-            if elapsed < 24:
-                log_msg += f"{elapsed:2.2f} hours elapsed"
-                self.log(log_msg, LogLevel.DEBUG)
-                return res
-
-            elapsed /= 24
-            log_msg += f"{elapsed:.2f} days elapsed"
+            elapsed *= (10 ** -9)
+            log_msg = f"{func.__name__}: {convert.as_time(elapsed)} elapsed"
             self.log(log_msg, LogLevel.DEBUG)
             return res
 

--- a/src/test/convert_test.py
+++ b/src/test/convert_test.py
@@ -21,6 +21,7 @@ def test_as_time():
     assert convert.as_time(100000) == "1.2d"
     assert convert.as_time(30000000) == "347.2d"
     assert convert.as_time(300000000) == "9.5y"
+    assert convert.as_time(0) == "0.0s"
 
     with pytest.raises(WrongTypeError):
         convert.as_time(None)
@@ -30,6 +31,8 @@ def test_as_time():
         convert.as_time("1")
     with pytest.raises(WrongTypeError):
         convert.as_time([1, 2])
+    with pytest.raises(ValueError):
+        convert.as_time(-1)
 
 def test_as_bytes():
     """Ensure that convert.as_bytes works as expected"""
@@ -38,7 +41,9 @@ def test_as_bytes():
     assert convert.as_bytes(1000) == "1.0kB"
     assert convert.as_bytes(1000.00) == "1.0kB"
     assert convert.as_bytes(12345678) == "12.3MB"
+    assert convert.as_bytes(12300000000) == "12.3GB"
     assert convert.as_bytes(9876543219876) == "9.9TB"
+    assert convert.as_bytes(0) == "0.0B"
 
     with pytest.raises(WrongTypeError):
         convert.as_bytes(None)
@@ -48,6 +53,8 @@ def test_as_bytes():
         convert.as_bytes("1")
     with pytest.raises(WrongTypeError):
         convert.as_bytes([1, 2])
+    with pytest.raises(ValueError):
+        convert.as_bytes(-1)
 
 def test_get_bytes():
     """Ensure that convert.get_bytes works as expected"""
@@ -55,7 +62,12 @@ def test_get_bytes():
     assert callable(convert.get_bytes)
     assert convert.get_bytes("1.0kB") == 1000
     assert convert.get_bytes("12.3MB") == 12300000
+    assert convert.get_bytes("12.3GB") == 12300000000
     assert convert.get_bytes("9.9TB") == 9900000000000
+    assert convert.get_bytes("0.0B") == 0
+    assert convert.get_bytes("0B") == 0
+    assert convert.get_bytes("0.0") == 0
+    assert convert.get_bytes("0") == 0
 
     with pytest.raises(WrongTypeError):
         convert.get_bytes(None)
@@ -67,3 +79,11 @@ def test_get_bytes():
         convert.get_bytes("test")
     with pytest.raises(ValueError):
         convert.get_bytes("1a2.3B")
+    with pytest.raises(ValueError):
+        convert.get_bytes("-1")
+    with pytest.raises(ValueError):
+        convert.get_bytes("-1.0")
+    with pytest.raises(ValueError):
+        convert.get_bytes("-1B")
+    with pytest.raises(ValueError):
+        convert.get_bytes("-1.0TB")

--- a/src/test/convert_test.py
+++ b/src/test/convert_test.py
@@ -1,0 +1,45 @@
+"""Module containing tests for the abllib.convert module"""
+
+import pytest
+
+from abllib import convert
+from abllib.error import WrongTypeError
+
+# pylint: disable=missing-class-docstring
+
+def test_as_bytes():
+    """Ensure that convert.as_bytes works as expected"""
+
+    assert callable(convert.as_bytes)
+    assert convert.as_bytes(1000) == "1.0kB"
+    assert convert.as_bytes(1000.00) == "1.0kB"
+    assert convert.as_bytes(12345678) == "12.3MB"
+    assert convert.as_bytes(9876543219876) == "9.9TB"
+
+    with pytest.raises(WrongTypeError):
+        convert.as_bytes(None)
+    with pytest.raises(WrongTypeError):
+        convert.as_bytes("test")
+    with pytest.raises(WrongTypeError):
+        convert.as_bytes("1")
+    with pytest.raises(WrongTypeError):
+        convert.as_bytes([1, 2])
+
+def test_get_bytes():
+    """Ensure that convert.get_bytes works as expected"""
+
+    assert callable(convert.get_bytes)
+    assert convert.get_bytes("1.0kB") == 1000
+    assert convert.get_bytes("12.3MB") == 12300000
+    assert convert.get_bytes("9.9TB") == 9900000000000
+
+    with pytest.raises(WrongTypeError):
+        convert.get_bytes(None)
+    with pytest.raises(WrongTypeError):
+        convert.get_bytes(10)
+    with pytest.raises(WrongTypeError):
+        convert.get_bytes([1, 2])
+    with pytest.raises(ValueError):
+        convert.get_bytes("test")
+    with pytest.raises(ValueError):
+        convert.get_bytes("1a2.3B")

--- a/src/test/convert_test.py
+++ b/src/test/convert_test.py
@@ -7,6 +7,30 @@ from abllib.error import WrongTypeError
 
 # pylint: disable=missing-class-docstring
 
+def test_as_time():
+    """Ensure that convert.as_time works as expected"""
+
+    assert callable(convert.as_time)
+    assert convert.as_time(0.000072) == "72.0μs"
+    assert convert.as_time(0.0072) == "7.2ms"
+    assert convert.as_time(10) == "10.0s"
+    assert convert.as_time(1000) == "16.7min"
+    assert convert.as_time(1000.00) == "16.7min"
+    assert convert.as_time(7200) == "2.0h"
+    assert convert.as_time(86000) == "23.9h"
+    assert convert.as_time(100000) == "1.2d"
+    assert convert.as_time(30000000) == "347.2d"
+    assert convert.as_time(300000000) == "9.5y"
+
+    with pytest.raises(WrongTypeError):
+        convert.as_time(None)
+    with pytest.raises(WrongTypeError):
+        convert.as_time("test")
+    with pytest.raises(WrongTypeError):
+        convert.as_time("1")
+    with pytest.raises(WrongTypeError):
+        convert.as_time([1, 2])
+
 def test_as_bytes():
     """Ensure that convert.as_bytes works as expected"""
 

--- a/src/test/convert_test.py
+++ b/src/test/convert_test.py
@@ -23,6 +23,9 @@ def test_as_time():
     assert convert.as_time(300000000) == "9.5y"
     assert convert.as_time(0) == "0.0s"
 
+    assert convert.as_time(1 * (10 ** 9)) == "31.7y"
+    assert convert.as_time(1 * (10 ** -9)) == "1.0ns"
+
     with pytest.raises(WrongTypeError):
         convert.as_time(None)
     with pytest.raises(WrongTypeError):

--- a/src/test/wrapper_test.py
+++ b/src/test/wrapper_test.py
@@ -518,7 +518,7 @@ def test_timeit_default(capture_logs):
         sleep(1)
     @wrapper.timeit
     def func5():
-        sleep(10)
+        sleep(2.7)
 
 
     func1()
@@ -532,11 +532,11 @@ def test_timeit_default(capture_logs):
         content = f.readlines()
 
         assert len(content) == 5
-        assert re.match(r'\[.*\] \[DEBUG   \] root: func1: \d{1}\.\d{2} ms elapsed', content[0])
-        assert re.match(r'\[.*\] \[DEBUG   \] root: func2: \d{2}\.\d{2} ms elapsed', content[1])
-        assert re.match(r'\[.*\] \[DEBUG   \] root: func3: \d{3}\.\d{2} ms elapsed', content[2])
-        assert re.match(r'\[.*\] \[DEBUG   \] root: func4: \d{1}\.\d{2} s elapsed', content[3])
-        assert re.match(r'\[.*\] \[DEBUG   \] root: func5: \d{2}\.\d{2} s elapsed', content[4])
+        assert re.match(r'\[.*\] \[DEBUG   \] root: func1: \d{1}\.\d{1}ms elapsed', content[0])
+        assert re.match(r'\[.*\] \[DEBUG   \] root: func2: \d{2}\.\d{1}ms elapsed', content[1])
+        assert re.match(r'\[.*\] \[DEBUG   \] root: func3: \d{3}\.\d{1}ms elapsed', content[2])
+        assert re.match(r'\[.*\] \[DEBUG   \] root: func4: \d{1}\.\d{1}s elapsed', content[3])
+        assert re.match(r'\[.*\] \[DEBUG   \] root: func5: \d{1}\.\d{1}s elapsed', content[4])
 
 def test_timeit_loggername(capture_logs):
     """Ensure that timeit uses the provided logger name"""
@@ -552,7 +552,7 @@ def test_timeit_loggername(capture_logs):
         content = f.readlines()
 
         assert len(content) == 1
-        assert re.match(r'\[.*\] \[DEBUG   \] SpecialLogger: func1: \d{1}\.\d{2} ms elapsed', content[0])
+        assert re.match(r'\[.*\] \[DEBUG   \] SpecialLogger: func1: \d{1}\.\d{1}ms elapsed', content[0])
 
 def test_timeit_custom_logger(capture_logs):
     """Ensure that timeit uses a custom provided logger"""
@@ -568,4 +568,4 @@ def test_timeit_custom_logger(capture_logs):
         content = f.readlines()
 
         assert len(content) == 1
-        assert re.match(r'\[.*\] \[DEBUG   \] ExtraLogger: func1: \d{1}\.\d{2} ms elapsed', content[0])
+        assert re.match(r'\[.*\] \[DEBUG   \] ExtraLogger: func1: \d{1}\.\d{1}ms elapsed', content[0])


### PR DESCRIPTION
## Description

Add a new module `abllib.convert` which converts numbers to a human-readable format and back.

## Checklist before merging

* [x] applied `ready-to-merge` label
* [x] updated documentation ([README.md](../README.md))
* [x] incremented version number ([pyproject.toml](../pyproject.toml))
