### PR TITLE
[maint] Fix pylance import warnings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -28,7 +28,8 @@ disable=too-many-arguments,
         too-many-positional-arguments,
         logging-fstring-interpolation,
         too-many-branches,
-        too-many-locals
+        too-many-locals,
+        useless-import-alias
 
 [FORMAT]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "abllib"
-version = "1.4.4rc5"
+version = "1.4.4rc6"
 authors = [
   { name="Ableytner", email="ableytner@gmx.at" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,9 @@ select = ["TID252"]
 ban-relative-imports = "all"
 
 [tool.isort]
-lines_after_imports=1
+lines_after_imports = 1
+line_length = 120
+multi_line_output = 1
 
 [tool.mypy]
 warn_return_any = true

--- a/src/abllib/__init__.py
+++ b/src/abllib/__init__.py
@@ -4,13 +4,28 @@ Ableytner's library for Python
 Contains many general-purpose functions which can be used across projects.
 """
 
-from abllib import (alg, enum, error, fs, fuzzy, general, log, onexit, pproc,
-                    storage, wrapper)
-from abllib.general import try_import_module
-from abllib.log import LogLevel, get_logger
-from abllib.storage import (CacheStorage, PersistentStorage, StorageView,
-                            VolatileStorage)
-from abllib.wrapper import Lock, NamedLock, NamedSemaphore, Semaphore
+from abllib import alg as alg
+from abllib import enum as enum
+from abllib import error as error
+from abllib import fs as fs
+from abllib import fuzzy as fuzzy
+from abllib import general as general
+from abllib import log as log
+from abllib import onexit as onexit
+from abllib import pproc as pproc
+from abllib import storage as storage
+from abllib import wrapper as wrapper
+from abllib.general import try_import_module as try_import_module
+from abllib.log import LogLevel as LogLevel
+from abllib.log import get_logger as get_logger
+from abllib.storage import CacheStorage as CacheStorage
+from abllib.storage import PersistentStorage as PersistentStorage
+from abllib.storage import StorageView as StorageView
+from abllib.storage import VolatileStorage as VolatileStorage
+from abllib.wrapper import Lock as Lock
+from abllib.wrapper import NamedLock as NamedLock
+from abllib.wrapper import NamedSemaphore as NamedSemaphore
+from abllib.wrapper import Semaphore as Semaphore
 
 __exports__ = [
     alg,

--- a/src/abllib/alg/__init__.py
+++ b/src/abllib/alg/__init__.py
@@ -16,6 +16,6 @@ else:
 
 levenshtein_distance: Callable[[str, str], int]
 
-__exports__ = [
-    levenshtein_distance
+__all__ = [
+    "levenshtein_distance"
 ]

--- a/src/abllib/error/__init__.py
+++ b/src/abllib/error/__init__.py
@@ -1,20 +1,26 @@
 """A module containing custom errors"""
 
 from abllib.error._custom_exception import CustomException
-from abllib.error._general import (ArgumentCombinationError,
-                                   CalledMultipleTimesError, DeprecatedError,
-                                   DirNotFoundError, InternalCalculationError,
-                                   InternalFunctionUsedError, InvalidKeyError,
-                                   KeyNotFoundError,
-                                   LockAcquisitionTimeoutError,
-                                   MissingDefaultMessageError,
-                                   MissingInheritanceError,
-                                   MissingRequiredModuleError,
-                                   NameNotFoundError, NoneTypeError,
-                                   NotInitializedError, ReadonlyError,
-                                   RegisteredMultipleTimesError,
-                                   SingletonInstantiationError,
-                                   UninitializedFieldError, WrongTypeError)
+from abllib.error._general import ArgumentCombinationError as ArgumentCombinationError
+from abllib.error._general import CalledMultipleTimesError as CalledMultipleTimesError
+from abllib.error._general import DeprecatedError as DeprecatedError
+from abllib.error._general import DirNotFoundError as DirNotFoundError
+from abllib.error._general import InternalCalculationError as InternalCalculationError
+from abllib.error._general import InternalFunctionUsedError as InternalFunctionUsedError
+from abllib.error._general import InvalidKeyError as InvalidKeyError
+from abllib.error._general import KeyNotFoundError as KeyNotFoundError
+from abllib.error._general import LockAcquisitionTimeoutError as LockAcquisitionTimeoutError
+from abllib.error._general import MissingDefaultMessageError as MissingDefaultMessageError
+from abllib.error._general import MissingInheritanceError as MissingInheritanceError
+from abllib.error._general import MissingRequiredModuleError as MissingRequiredModuleError
+from abllib.error._general import NameNotFoundError as NameNotFoundError
+from abllib.error._general import NoneTypeError as NoneTypeError
+from abllib.error._general import NotInitializedError as NotInitializedError
+from abllib.error._general import ReadonlyError as ReadonlyError
+from abllib.error._general import RegisteredMultipleTimesError as RegisteredMultipleTimesError
+from abllib.error._general import SingletonInstantiationError as SingletonInstantiationError
+from abllib.error._general import UninitializedFieldError as UninitializedFieldError
+from abllib.error._general import WrongTypeError as WrongTypeError
 
 INTERNAL =  "Internal error, please report it on github!"
 

--- a/src/abllib/fs/__init__.py
+++ b/src/abllib/fs/__init__.py
@@ -1,7 +1,7 @@
 """A module containing file system-related functionality"""
 
-from abllib.fs.filename import sanitize
-from abllib.fs.path import absolute
+from abllib.fs.filename import sanitize as sanitize
+from abllib.fs.path import absolute as absolute
 
 __exports__ = [
     absolute,

--- a/src/abllib/fuzzy/__init__.py
+++ b/src/abllib/fuzzy/__init__.py
@@ -1,9 +1,9 @@
 """A module containing fuzzy matching-related functionality"""
 
-from abllib.fuzzy._all import match_all
-from abllib.fuzzy._closest import match_closest
-from abllib.fuzzy._matchresult import MatchResult
-from abllib.fuzzy._similarity import Similarity
+from abllib.fuzzy._all import match_all as match_all
+from abllib.fuzzy._closest import match_closest as match_closest
+from abllib.fuzzy._matchresult import MatchResult as MatchResult
+from abllib.fuzzy._similarity import Similarity as Similarity
 
 def similarity(target: str, candidate: str) -> float:
     """

--- a/src/abllib/log.py
+++ b/src/abllib/log.py
@@ -48,14 +48,7 @@ class LogLevel(Enum):
             case _:
                 raise error.NameNotFoundError(f"'{log_level}' isn't a known log level")
 
-def initialize(log_level: Literal[LogLevel.CRITICAL]
-                          | Literal[LogLevel.ERROR]
-                          | Literal[LogLevel.WARNING]
-                          | Literal[LogLevel.INFO]
-                          | Literal[LogLevel.DEBUG]
-                          | Literal[LogLevel.ALL]
-                          | int
-                          | None = None) -> None:
+def initialize(log_level: LogLevel | int | None = None) -> None:
     """
     Initialize the custom logging module.
 
@@ -170,13 +163,7 @@ def get_logger(name: str | None = None) -> logging.Logger:
 
     return logging.getLogger(name)
 
-def get_loglevel() -> Literal[LogLevel.CRITICAL] \
-                      | Literal[LogLevel.ERROR] \
-                      | Literal[LogLevel.INFO] \
-                      | Literal[LogLevel.WARNING] \
-                      | Literal[LogLevel.DEBUG] \
-                      | Literal[LogLevel.ALL] \
-                      | None:
+def get_loglevel() -> LogLevel | None:
     """Return the current LogLevel"""
 
     return LogLevel(InternalStorage["_log.level"]) if "_log.level" in InternalStorage else None

--- a/src/abllib/pproc/__init__.py
+++ b/src/abllib/pproc/__init__.py
@@ -1,8 +1,9 @@
 """A module containing parallel processing-related functionality, both with threads and processes"""
 
-from abllib.pproc._worker_process import WorkerProcess
-from abllib.pproc._worker_thread import WorkerThread
-from abllib.wrapper import Lock, Semaphore
+from abllib.pproc._worker_process import WorkerProcess as WorkerProcess
+from abllib.pproc._worker_thread import WorkerThread as WorkerThread
+from abllib.wrapper import Lock as Lock
+from abllib.wrapper import Semaphore as Semaphore
 
 __exports__ = [
     WorkerProcess,

--- a/src/abllib/wrapper/__init__.py
+++ b/src/abllib/wrapper/__init__.py
@@ -1,13 +1,16 @@
 """A module containing various wrappers"""
 
-from abllib.wrapper._deprecated import deprecated
-from abllib.wrapper._lock import Lock, Semaphore
-from abllib.wrapper._lock_wrapper import (NamedLock, NamedSemaphore, ReadLock,
-                                          WriteLock)
-from abllib.wrapper._log_error import log_error
-from abllib.wrapper._log_io import log_io
-from abllib.wrapper._singleuse_wrapper import singleuse
-from abllib.wrapper._timeit import timeit
+from abllib.wrapper._deprecated import deprecated as deprecated
+from abllib.wrapper._lock import Lock as Lock
+from abllib.wrapper._lock import Semaphore as Semaphore
+from abllib.wrapper._lock_wrapper import NamedLock as NamedLock
+from abllib.wrapper._lock_wrapper import NamedSemaphore as NamedSemaphore
+from abllib.wrapper._lock_wrapper import ReadLock as ReadLock
+from abllib.wrapper._lock_wrapper import WriteLock as WriteLock
+from abllib.wrapper._log_error import log_error as log_error
+from abllib.wrapper._log_io import log_io as log_io
+from abllib.wrapper._singleuse_wrapper import singleuse as singleuse
+from abllib.wrapper._timeit import timeit as timeit
 
 __exports__ = [
     Lock,

--- a/src/test/i_storage_test.py
+++ b/src/test/i_storage_test.py
@@ -3,9 +3,12 @@
 import pytest
 
 from abllib._storage import _BaseStorage, _InternalStorage
-from abllib.error import (InternalFunctionUsedError, InvalidKeyError,
-                          KeyNotFoundError, ReadonlyError,
-                          SingletonInstantiationError, UninitializedFieldError,
+from abllib.error import (InternalFunctionUsedError,
+                          InvalidKeyError,
+                          KeyNotFoundError,
+                          ReadonlyError,
+                          SingletonInstantiationError,
+                          UninitializedFieldError,
                           WrongTypeError)
 
 # pylint: disable=protected-access, missing-class-docstring, pointless-statement, expression-not-assigned

--- a/src/test/storage_test.py
+++ b/src/test/storage_test.py
@@ -7,8 +7,7 @@ import pytest
 
 from abllib import _storage, error
 from abllib._storage._base_storage import _BaseStorage
-from abllib.storage import (_CacheStorage, _PersistentStorage, _StorageView,
-                            _ThreadsafeStorage, _VolatileStorage)
+from abllib.storage import _CacheStorage, _PersistentStorage, _StorageView, _ThreadsafeStorage, _VolatileStorage
 
 # pylint: disable=protected-access, missing-class-docstring, pointless-statement, expression-not-assigned
 


### PR DESCRIPTION
## Description

Follow-up for https://github.com/Ableytner/abllib/pull/46

Because this library is py.typed, we need to explicitly export the modules in __init__.py

See: https://github.com/microsoft/pylance-release/issues/2953#issuecomment-1168408943

## Checklist before merging

* [x] applied `ready-to-merge` label
* [x] updated documentation ([README.md](../README.md))
* [x] incremented version number ([pyproject.toml](../pyproject.toml))
